### PR TITLE
Allow missing accept-encoding header

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Currently the following headers are supported:
 - `'gzip'`
 - `'br'`
 
-If an unsupported encoding is received, it will automatically return a `406` error, if the `'accept-encoding'` header is missing, it will return a `400` error.
+If an unsupported encoding is received, it will automatically return a `406` error, if the `'accept-encoding'` header is missing, it will not compress the payload.
 
 It automatically defines if a payload should be compressed or not based on its `Content-Type`, if no content type is present, it will assume is `application/json`.
 

--- a/index.js
+++ b/index.js
@@ -45,13 +45,7 @@ function compressPlugin (fastify, opts, next) {
 
     var encoding = getEncodingHeader(this.request)
 
-    if (encoding === undefined) {
-      closeStream(payload)
-      this.code(400).send(new Error('Missing `accept encoding` header'))
-      return
-    }
-
-    if (encoding === 'identity') {
+    if (encoding === undefined || encoding === 'identity') {
       return this.send(payload)
     }
 
@@ -96,13 +90,6 @@ function compressPlugin (fastify, opts, next) {
 
     var encoding = getEncodingHeader(req)
 
-    if (encoding === undefined) {
-      closeStream(payload)
-      reply.code(400)
-      next(new Error('Missing `accept encoding` header'))
-      return
-    }
-
     if (encoding === null) {
       closeStream(payload)
       reply.code(406)
@@ -110,7 +97,7 @@ function compressPlugin (fastify, opts, next) {
       return
     }
 
-    if (encoding === 'identity') {
+    if (encoding === undefined || encoding === 'identity') {
       return next()
     }
 

--- a/test.js
+++ b/test.js
@@ -146,7 +146,7 @@ test('should not compress on missing header', t => {
   })
 })
 
-test('Should not compress on missing header', t => {
+test('Should close the stream', t => {
   t.plan(3)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false })
@@ -159,10 +159,18 @@ test('Should not compress on missing header', t => {
 
   fastify.inject({
     url: '/',
-    method: 'GET'
+    method: 'GET',
+    headers: {
+      'accept-encoding': 'compress'
+    }
   }, res => {
-    t.strictEqual(res.statusCode, 200)
-    t.notOk(res.headers['content-encoding'])
+    const payload = JSON.parse(res.payload)
+    t.strictEqual(res.statusCode, 406)
+    t.deepEqual({
+      error: 'Not Acceptable',
+      message: 'Unsupported encoding',
+      statusCode: 406
+    }, payload)
   })
 })
 

--- a/test.js
+++ b/test.js
@@ -128,7 +128,7 @@ test('Unsupported encoding', t => {
   })
 })
 
-test('Missing header', t => {
+test('should not compress on missing header', t => {
   t.plan(2)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false })
@@ -141,17 +141,12 @@ test('Missing header', t => {
     url: '/',
     method: 'GET'
   }, res => {
-    const payload = JSON.parse(res.payload)
-    t.strictEqual(res.statusCode, 400)
-    t.deepEqual({
-      error: 'Bad Request',
-      message: 'Missing `accept encoding` header',
-      statusCode: 400
-    }, payload)
+    t.strictEqual(res.statusCode, 200)
+    t.notOk(res.headers['content-encoding'])
   })
 })
 
-test('Should close the stream', t => {
+test('Should not compress on missing header', t => {
   t.plan(3)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false })
@@ -166,13 +161,8 @@ test('Should close the stream', t => {
     url: '/',
     method: 'GET'
   }, res => {
-    const payload = JSON.parse(res.payload)
-    t.strictEqual(res.statusCode, 400)
-    t.deepEqual({
-      error: 'Bad Request',
-      message: 'Missing `accept encoding` header',
-      statusCode: 400
-    }, payload)
+    t.strictEqual(res.statusCode, 200)
+    t.notOk(res.headers['content-encoding'])
   })
 })
 


### PR DESCRIPTION
According to [https://tools.ietf.org/html/rfc7231#section-5.3.4](https://tools.ietf.org/html/rfc7231#section-5.3.4) a missing accept-encoding header is valid.

In this case no error should be send and the payload should not be compressed.