### PR TITLE
Support asterisk in accept-encoding header

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@ Currently the following headers are supported:
 - `'deflate'`
 - `'gzip'`
 - `'br'`
+- `'*'`
+
+If the `'accept-encoding'` header specifies no preferred encoding with an asterisk `*` the payload will be compressed with `gzip`.
 
 If an unsupported encoding is received, it will automatically return a `406` error, if the `'accept-encoding'` header is missing, it will return a `400` error.
 

--- a/index.js
+++ b/index.js
@@ -155,6 +155,9 @@ function getEncodingHeader (request) {
     if (supportedEncodings.indexOf(acceptEncodings[i]) > -1) {
       return acceptEncodings[i]
     }
+    if (acceptEncodings[i].indexOf('*') > -1) {
+      return 'gzip'
+    }
   }
   return null
 }

--- a/test.js
+++ b/test.js
@@ -56,6 +56,29 @@ test('should send a gzipped data', t => {
   })
 })
 
+test('should send a gzipped data for * header', t => {
+  t.plan(2)
+  const fastify = Fastify()
+  fastify.register(compressPlugin, { global: false })
+
+  fastify.get('/', (req, reply) => {
+    reply.type('text/plain').compress(createReadStream('./package.json'))
+  })
+
+  fastify.inject({
+    url: '/',
+    method: 'GET',
+    headers: {
+      'accept-encoding': '*'
+    }
+  }, res => {
+    t.strictEqual(res.headers['content-encoding'], 'gzip')
+    const file = readFileSync('./package.json', 'utf8')
+    const payload = zlib.gunzipSync(res.rawPayload)
+    t.strictEqual(payload.toString('utf-8'), file)
+  })
+})
+
 test('should send a brotli data', t => {
   t.plan(2)
   const fastify = Fastify()


### PR DESCRIPTION
This PR adds support for an asterisk `*` in the `accept-encoding` header.