### PR TITLE
Updates fastify, plugin-meta

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,4 +152,7 @@ function shouldCompress (type) {
   return data.compressible
 }
 
-module.exports = fp(compressPlugin, '>=0.20.0')
+module.exports = fp(compressPlugin, {
+  fastify: '>=0.39.1',
+  name: 'fastify-compress'
+})

--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "string-to-stream": "^1.1.0"
   },
   "devDependencies": {
-    "fastify": "^0.35.3",
+    "fastify": "^0.39.1",
     "iltorb": "^2.0.3",
     "standard": "^10.0.3",
-    "tap": "^11.0.0"
+    "tap": "^11.0.1"
   },
   "scripts": {
     "unit": "tap test.js",

--- a/test.js
+++ b/test.js
@@ -11,7 +11,7 @@ const Fastify = require('fastify')
 const compressPlugin = require('./index')
 
 test('should send a deflated data', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false })
 
@@ -25,7 +25,8 @@ test('should send a deflated data', t => {
     headers: {
       'accept-encoding': 'deflate'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     t.strictEqual(res.headers['content-encoding'], 'deflate')
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.inflateSync(res.rawPayload)
@@ -34,7 +35,7 @@ test('should send a deflated data', t => {
 })
 
 test('should send a gzipped data', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false })
 
@@ -48,7 +49,8 @@ test('should send a gzipped data', t => {
     headers: {
       'accept-encoding': 'gzip'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     t.strictEqual(res.headers['content-encoding'], 'gzip')
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.gunzipSync(res.rawPayload)
@@ -57,7 +59,7 @@ test('should send a gzipped data', t => {
 })
 
 test('should send a gzipped data for * header', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false })
 
@@ -71,7 +73,8 @@ test('should send a gzipped data for * header', t => {
     headers: {
       'accept-encoding': '*'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     t.strictEqual(res.headers['content-encoding'], 'gzip')
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.gunzipSync(res.rawPayload)
@@ -80,7 +83,7 @@ test('should send a gzipped data for * header', t => {
 })
 
 test('should send a brotli data', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
   fastify.register(compressPlugin, { brotli, global: false })
 
@@ -94,7 +97,8 @@ test('should send a brotli data', t => {
     headers: {
       'accept-encoding': 'br'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     t.strictEqual(res.headers['content-encoding'], 'br')
     const file = readFileSync('./package.json', 'utf8')
     const payload = brotli.decompressSync(res.rawPayload)
@@ -103,7 +107,7 @@ test('should send a brotli data', t => {
 })
 
 test('should follow the encoding order', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
   fastify.register(compressPlugin, { brotli, global: false })
 
@@ -117,7 +121,8 @@ test('should follow the encoding order', t => {
     headers: {
       'accept-encoding': 'hello,br'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     t.strictEqual(res.headers['content-encoding'], 'br')
     const file = readFileSync('./package.json', 'utf8')
     const payload = brotli.decompressSync(res.rawPayload)
@@ -126,7 +131,7 @@ test('should follow the encoding order', t => {
 })
 
 test('Unsupported encoding', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false })
 
@@ -140,7 +145,8 @@ test('Unsupported encoding', t => {
     headers: {
       'accept-encoding': 'hello'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     const payload = JSON.parse(res.payload)
     t.strictEqual(res.statusCode, 406)
     t.deepEqual({
@@ -152,7 +158,7 @@ test('Unsupported encoding', t => {
 })
 
 test('should not compress on missing header', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false })
 
@@ -163,14 +169,15 @@ test('should not compress on missing header', t => {
   fastify.inject({
     url: '/',
     method: 'GET'
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     t.strictEqual(res.statusCode, 200)
     t.notOk(res.headers['content-encoding'])
   })
 })
 
 test('Should close the stream', t => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false })
 
@@ -183,7 +190,8 @@ test('Should close the stream', t => {
   fastify.inject({
     url: '/',
     method: 'GET'
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     const file = readFileSync('./package.json', 'utf8')
     t.strictEqual(res.statusCode, 200)
     t.strictEqual(file, res.payload)
@@ -191,7 +199,7 @@ test('Should close the stream', t => {
 })
 
 test('Should send 406 error on invalid accept encoding', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: true })
 
@@ -206,7 +214,8 @@ test('Should send 406 error on invalid accept encoding', t => {
     headers: {
       'accept-encoding': 'invalid'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     const payload = JSON.parse(res.payload)
     t.strictEqual(res.statusCode, 406)
     t.deepEqual({
@@ -218,7 +227,7 @@ test('Should send 406 error on invalid accept encoding', t => {
 })
 
 test('No compression header', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false, threshold: 0 })
 
@@ -232,7 +241,8 @@ test('No compression header', t => {
     headers: {
       'x-no-compression': true
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     const payload = JSON.parse(res.payload)
     t.notOk(res.headers['content-encoding'])
     t.deepEqual({ hello: 'world' }, payload)
@@ -240,7 +250,7 @@ test('No compression header', t => {
 })
 
 test('Should compress json data (gzip)', t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false, threshold: 0 })
   const json = { hello: 'world' }
@@ -255,14 +265,15 @@ test('Should compress json data (gzip)', t => {
     headers: {
       'accept-encoding': 'gzip'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     const payload = zlib.gunzipSync(res.rawPayload)
     t.strictEqual(payload.toString('utf-8'), JSON.stringify(json))
   })
 })
 
 test('Should compress json data (deflate)', t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false, threshold: 0 })
   const json = { hello: 'world' }
@@ -277,14 +288,15 @@ test('Should compress json data (deflate)', t => {
     headers: {
       'accept-encoding': 'deflate'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     const payload = zlib.inflateSync(res.rawPayload)
     t.strictEqual(payload.toString('utf-8'), JSON.stringify(json))
   })
 })
 
 test('Should compress json data (brotli)', t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false, brotli, threshold: 0 })
   const json = { hello: 'world' }
@@ -299,14 +311,15 @@ test('Should compress json data (brotli)', t => {
     headers: {
       'accept-encoding': 'br'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     const payload = brotli.decompressSync(res.rawPayload)
     t.strictEqual(payload.toString('utf-8'), JSON.stringify(json))
   })
 })
 
 test('Should compress string data (gzip)', t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false, threshold: 0 })
 
@@ -320,14 +333,15 @@ test('Should compress string data (gzip)', t => {
     headers: {
       'accept-encoding': 'gzip'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     const payload = zlib.gunzipSync(res.rawPayload)
     t.strictEqual(payload.toString('utf-8'), 'hello')
   })
 })
 
 test('Should compress string data (deflate)', t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false, threshold: 0 })
 
@@ -341,19 +355,20 @@ test('Should compress string data (deflate)', t => {
     headers: {
       'accept-encoding': 'deflate'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     const payload = zlib.inflateSync(res.rawPayload)
     t.strictEqual(payload.toString('utf-8'), 'hello')
   })
 })
 
 test('Should compress string data (brotli)', t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
   fastify.register(compressPlugin, { brotli, threshold: 0 })
 
   fastify.get('/', (req, reply) => {
-    reply.type('text/plain').compress('hello')
+    reply.type('text/plain').send('hello')
   })
 
   fastify.inject({
@@ -362,14 +377,15 @@ test('Should compress string data (brotli)', t => {
     headers: {
       'accept-encoding': 'br'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     const payload = brotli.decompressSync(res.rawPayload)
     t.strictEqual(payload.toString('utf-8'), 'hello')
   })
 })
 
 test('Missing payload', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false })
 
@@ -380,7 +396,8 @@ test('Missing payload', t => {
   fastify.inject({
     url: '/',
     method: 'GET'
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     const payload = JSON.parse(res.payload)
     t.strictEqual(res.statusCode, 500)
     t.deepEqual({
@@ -392,7 +409,7 @@ test('Missing payload', t => {
 })
 
 test('Should compress json data (gzip) - global', t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
   fastify.register(compressPlugin, { threshold: 0 })
   const json = { hello: 'world' }
@@ -407,14 +424,15 @@ test('Should compress json data (gzip) - global', t => {
     headers: {
       'accept-encoding': 'gzip'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     const payload = zlib.gunzipSync(res.rawPayload)
     t.strictEqual(payload.toString('utf-8'), JSON.stringify(json))
   })
 })
 
 test('Should not compress on x-no-compression header', t => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
   fastify.register(compressPlugin, { threshold: 0 })
   const json = { hello: 'world' }
@@ -429,7 +447,8 @@ test('Should not compress on x-no-compression header', t => {
     headers: {
       'x-no-compression': true
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     t.strictEqual(res.statusCode, 200)
     t.notOk(res.headers['content-encoding'])
     t.deepEqual(JSON.parse(res.payload), json)
@@ -437,7 +456,7 @@ test('Should not compress on x-no-compression header', t => {
 })
 
 test('Should not try compress missing payload', t => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
   fastify.register(compressPlugin, { threshold: 0 })
 
@@ -451,7 +470,8 @@ test('Should not try compress missing payload', t => {
     headers: {
       'accept-encoding': 'gzip'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     t.strictEqual(res.statusCode, 200)
     t.notOk(res.headers['content-encoding'])
     t.strictEqual(res.payload, '')
@@ -459,7 +479,7 @@ test('Should not try compress missing payload', t => {
 })
 
 test('Should not compress if content-type is a invalid type', t => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
   fastify.register(compressPlugin, { threshold: 0 })
 
@@ -474,7 +494,8 @@ test('Should not compress if content-type is a invalid type', t => {
     headers: {
       'accept-encoding': 'deflate'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     t.strictEqual(res.statusCode, 200)
     t.notOk(res.headers['content-encoding'])
     t.strictEqual(res.payload, 'a message')
@@ -482,7 +503,7 @@ test('Should not compress if content-type is a invalid type', t => {
 })
 
 test('Should not compress if content-type is a invalid type', t => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
   fastify.register(compressPlugin, { threshold: 0 })
 
@@ -496,7 +517,8 @@ test('Should not compress if content-type is a invalid type', t => {
     headers: {
       'accept-encoding': 'deflate'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     t.strictEqual(res.statusCode, 200)
     t.notOk(res.headers['content-encoding'])
     t.strictEqual(res.payload, 'a message')
@@ -504,7 +526,7 @@ test('Should not compress if content-type is a invalid type', t => {
 })
 
 test('Should not compress if payload length is smaller than threshold', t => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
   fastify.register(compressPlugin, { threshold: 128 })
 
@@ -518,7 +540,8 @@ test('Should not compress if payload length is smaller than threshold', t => {
     headers: {
       'accept-encoding': 'deflate'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     t.strictEqual(res.statusCode, 200)
     t.notOk(res.headers['content-encoding'])
     t.strictEqual(res.payload, 'a message')
@@ -526,7 +549,7 @@ test('Should not compress if payload length is smaller than threshold', t => {
 })
 
 test('Should compress json data (deflate) - global', t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
   fastify.register(compressPlugin, { threshold: 0 })
   const json = { hello: 'world' }
@@ -541,14 +564,15 @@ test('Should compress json data (deflate) - global', t => {
     headers: {
       'accept-encoding': 'deflate'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     const payload = zlib.inflateSync(res.rawPayload)
     t.strictEqual(payload.toString('utf-8'), JSON.stringify(json))
   })
 })
 
 test('Should compress json data (brotli) - global', t => {
-  t.plan(1)
+  t.plan(2)
   const fastify = Fastify()
   fastify.register(compressPlugin, { brotli, threshold: 0 })
   const json = { hello: 'world' }
@@ -563,14 +587,15 @@ test('Should compress json data (brotli) - global', t => {
     headers: {
       'accept-encoding': 'br'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     const payload = brotli.decompressSync(res.rawPayload)
     t.strictEqual(payload.toString('utf-8'), JSON.stringify(json))
   })
 })
 
 test('identity header (compress)', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false, threshold: 0 })
 
@@ -584,7 +609,8 @@ test('identity header (compress)', t => {
     headers: {
       'accept-encoding': 'identity'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     const payload = JSON.parse(res.payload)
     t.notOk(res.headers['content-encoding'])
     t.deepEqual({ hello: 'world' }, payload)
@@ -592,7 +618,7 @@ test('identity header (compress)', t => {
 })
 
 test('identity header (hook)', t => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
   fastify.register(compressPlugin, { threshold: 0 })
 
@@ -606,7 +632,8 @@ test('identity header (hook)', t => {
     headers: {
       'accept-encoding': 'identity'
     }
-  }, res => {
+  }, (err, res) => {
+    t.error(err)
     const payload = JSON.parse(res.payload)
     t.notOk(res.headers['content-encoding'])
     t.deepEqual({ hello: 'world' }, payload)


### PR DESCRIPTION
- Updates to fastify@0.39.1
- Updates to tap@11.0.1
- Adds `name` property to plugin-meta. see: https://github.com/fastify/fastify-plugin/issues/17#issuecomment-355972265

Please note, that in order to make test pass, I had to change `compress` to `send` at

https://github.com/lependu/fastify-compress/blame/71b4f7f8754589c78f94e7277de3342d001d733b/test.js#L371 

Otherwise it compresses the content twice. I could not figure out why is that, so I guess it needs a deeper review.