### PR TITLE
accept-encoding can contain whitespace

### DIFF
--- a/index.js
+++ b/index.js
@@ -132,10 +132,10 @@ function getEncodingHeader (request) {
   if (!header) return undefined
   var acceptEncodings = header.split(',')
   for (var i = 0; i < acceptEncodings.length; i++) {
-    if (supportedEncodings.indexOf(acceptEncodings[i]) > -1) {
-      return acceptEncodings[i]
+    if (supportedEncodings.indexOf(acceptEncodings[i].trim()) > -1) {
+      return acceptEncodings[i].trim()
     }
-    if (acceptEncodings[i].indexOf('*') > -1) {
+    if (acceptEncodings[i].trim().indexOf('*') > -1) {
       return 'gzip'
     }
   }

--- a/index.js
+++ b/index.js
@@ -132,10 +132,11 @@ function getEncodingHeader (request) {
   if (!header) return undefined
   var acceptEncodings = header.split(',')
   for (var i = 0; i < acceptEncodings.length; i++) {
-    if (supportedEncodings.indexOf(acceptEncodings[i].trim()) > -1) {
-      return acceptEncodings[i].trim()
+    var acceptEncoding = acceptEncodings[i].trim()
+    if (supportedEncodings.indexOf(acceptEncoding) > -1) {
+      return acceptEncoding
     }
-    if (acceptEncodings[i].trim().indexOf('*') > -1) {
+    if (acceptEncoding.indexOf('*') > -1) {
       return 'gzip'
     }
   }

--- a/test.js
+++ b/test.js
@@ -692,3 +692,27 @@ test('should support stream1 (global hook)', t => {
     t.deepEqual(JSON.parse(payload.toString()), [{ hello: 'world' }, { a: 42 }])
   })
 })
+
+test('accept-encoding can contain white space', t => {
+  t.plan(3)
+  const fastify = Fastify()
+  fastify.register(compressPlugin, { threshold: 0 })
+  const json = { hello: 'world' }
+
+  fastify.get('/', (req, reply) => {
+    reply.send(json)
+  })
+
+  fastify.inject({
+    url: '/',
+    method: 'GET',
+    headers: {
+      'accept-encoding': 'hello, gzip'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.headers['content-encoding'], 'gzip')
+    const payload = zlib.gunzipSync(res.rawPayload)
+    t.strictEqual(payload.toString('utf-8'), JSON.stringify(json))
+  })
+})


### PR DESCRIPTION
This will allow whitepsaces in accept-encoding headers.

While working on https://github.com/fastify/fastify-compress/pull/25 I discovered that accept headers with whitespace did not work.

Taken from a real request in the wild ```accept-encoding: "br, gzip, deflate"```