### PR TITLE
make compressibleTypes user settable so custom types can be compressed

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,14 @@ fastify.register(
   { threshold: 2048 }
 )
 ```
+### Compression Header Customization
+[mime-db](https://github.com/jshttp/mime-db) is used to determine if a `Content-Type` should be compressed. You can compress additional content types via regular expression.
+```javascript
+fastify.register(
+  require('fastify-compress'),
+  { customTypes: /^x-protobuf$/ }
+)
+```
 ### Brotli
 Brotli compression is not enabled by default, if you need it we recommend to install [`iltorb`](https://www.npmjs.com/package/iltorb) and pass it as option.
 ```javascript

--- a/README.md
+++ b/README.md
@@ -66,12 +66,12 @@ fastify.register(
   { threshold: 2048 }
 )
 ```
-### Compression Header Customization
+### customTypes
 [mime-db](https://github.com/jshttp/mime-db) is used to determine if a `Content-Type` should be compressed. You can compress additional content types via regular expression.
 ```javascript
 fastify.register(
   require('fastify-compress'),
-  { customTypes: /^x-protobuf$/ }
+  { customTypes: /x-protobuf$/ }
 )
 ```
 ### Brotli


### PR DESCRIPTION
The itch I'm scratching is I couldn't compress a protobuf content type, as it wasn't in mime-db or in the `compressibleTypes` constant. I was going to add it to `compressibleTypes`, but that didn't seem like a sustainable solution, so I made the `compressibleTypes` regex user configurable.

Since the types that were in `compressibleTypes` are also in mime-db, I'm guessing this is used to short circuit the mime-db check for performance. Figured overwriting `compressibleTypes` this way would be more performant than adding an additional regex check for a user passed expression (i.e. compressibleTypes.test(type) || someuserstuff.test(type)).