### PR TITLE
support custom deflate, inflate compressed bodies

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,20 @@ fastify.register(
 ### Disable compression by header
 You can selectively disable the response compression by using the `x-no-compression` header in the request.
 
+### Inflate pre-compressed bodies for clients that do not support compression
+Optional feature to inflate pre-compressed data if the client doesn't include one of the supported compression types in its `Accept-Encoding` header.
+```javascript
+fastify.register(
+  require('fastify-compress'),
+  { inflateIfDeflated: true }
+)
+
+fastify.get('/file', (req, reply) =>
+  // will inflate the file  on the way out for clients
+  // that indicate they do not support compression
+  reply.send(fs.createReadStream('./file.gz')))
+```
+
 ## Note
 Please have in mind that in large scale scenarios, you should use a proxy like Nginx to handle response-compression.
 

--- a/index.js
+++ b/index.js
@@ -71,6 +71,9 @@ function compressPlugin (fastify, opts, next) {
       if (!Buffer.isBuffer(payload) && typeof payload !== 'string') {
         payload = this.serialize(payload)
       }
+    }
+
+    if (typeof payload.pipe !== 'function') {
       if (Buffer.byteLength(payload) < threshold) {
         return this.send(payload)
       }

--- a/index.js
+++ b/index.js
@@ -15,6 +15,7 @@ function compressPlugin (fastify, opts, next) {
     fastify.addHook('onSend', onSend)
   }
 
+  const inflateIfDeflated = opts.inflateIfDeflated === true
   const threshold = typeof opts.threshold === 'number' ? opts.threshold : 1024
   const compressibleTypes = opts.customTypes instanceof RegExp ? opts.customTypes : /^text\/|\+json$|\+text$|\+xml$|octet-stream$/
   const compressStream = {

--- a/package.json
+++ b/package.json
@@ -5,17 +5,17 @@
   "main": "index.js",
   "dependencies": {
     "fastify-plugin": "^1.0.0",
-    "into-stream": "^3.1.0",
-    "is-stream": "^1.1.0",
+    "into-stream": "^4.0.0",
     "is-deflate": "^1.0.0",
     "is-gzip": "^1.0.0",
+    "is-stream": "^1.1.0",
     "is-zip": "^1.0.0",
     "mime-db": "^1.33.0",
+    "minipass": "2.3.5",
     "peek-stream": "^1.1.0",
     "pump": "^3.0.0",
     "pumpify": "^1.3.3",
     "string-to-stream": "^1.1.0",
-    "through2": "^2.0.3",
     "unzipper": "^0.8.9"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -5,9 +5,13 @@
   "main": "index.js",
   "dependencies": {
     "fastify-plugin": "^1.0.0",
-    "into-stream": "^4.0.0",
+    "into-stream": "^3.1.0",
+    "is-stream": "^1.1.0",
+    "is-zip": "^1.0.0",
     "mime-db": "^1.33.0",
-    "pump": "^3.0.0"
+    "pump": "^3.0.0",
+    "string-to-stream": "^1.1.0",
+    "unzip-if-zip": "^1.0.0"
   },
   "devDependencies": {
     "fastify": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -7,11 +7,16 @@
     "fastify-plugin": "^1.0.0",
     "into-stream": "^3.1.0",
     "is-stream": "^1.1.0",
+    "is-deflate": "^1.0.0",
+    "is-gzip": "^1.0.0",
     "is-zip": "^1.0.0",
     "mime-db": "^1.33.0",
+    "peek-stream": "^1.1.0",
     "pump": "^3.0.0",
+    "pumpify": "^1.3.3",
     "string-to-stream": "^1.1.0",
-    "unzip-if-zip": "^1.0.0"
+    "through2": "^2.0.3",
+    "unzipper": "^0.8.9"
   },
   "devDependencies": {
     "fastify": "^1.3.0",

--- a/test.js
+++ b/test.js
@@ -143,6 +143,33 @@ test('should not double-compress Stream if already zipped', t => {
   })
 })
 
+test('onSend hook should not double-compress Stream if already zipped', t => {
+  t.plan(3)
+  const fastify = Fastify()
+  fastify.register(compressPlugin, { global: true })
+
+  fastify.get('/', (req, reply) => {
+    reply.type('text/plain').compress(
+      createReadStream('./package.json')
+        .pipe(zlib.createGzip())
+    )
+  })
+
+  fastify.inject({
+    url: '/',
+    method: 'GET',
+    headers: {
+      'accept-encoding': 'gzip'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.headers['content-encoding'], 'gzip')
+    const file = readFileSync('./package.json', 'utf8')
+    const payload = zlib.gunzipSync(res.rawPayload)
+    t.strictEqual(payload.toString('utf-8'), file)
+  })
+})
+
 test('should send a gzipped data for * header', t => {
   t.plan(3)
   const fastify = Fastify()

--- a/test.js
+++ b/test.js
@@ -309,29 +309,6 @@ test('should decompress compressed Buffers on missing header', t => {
   })
 })
 
-// This throws an error, because the Reply's `send` method attempts
-// to JSON.parse the compressed string before the `onSend` hook is invoked
-// test('should decompress compressed Strings on missing header', t => {
-//   t.plan(4)
-//   const fastify = Fastify()
-//   fastify.register(compressPlugin, { threshold: 0, inflateIfDeflated: true })
-//   const json = { hello: 'world' }
-
-//   fastify.get('/', (req, reply) => {
-//     reply.send(zlib.gzipSync(JSON.stringify(json)).toString())
-//   })
-
-//   fastify.inject({
-//     url: '/',
-//     method: 'GET'
-//   }, (err, res) => {
-//     t.error(err)
-//     t.strictEqual(res.statusCode, 200)
-//     t.notOk(res.headers['content-encoding'])
-//     t.deepEqual(JSON.parse('' + res.payload), json)
-//   })
-// })
-
 test('should decompress compressed Streams on missing header', t => {
   t.plan(4)
   const fastify = Fastify()


### PR DESCRIPTION
This PR adds support for providing custom implementations of `createGzip` and `createDeflate` and inflating already-compressed response bodies if the client doesn't support compression.

Overriding `createGzip` allows swapping out gzip with [`pigz`](https://github.com/madler/pigz), useful for multi-megabyte dynamic payloads:
```js
const es = require('event-stream')
const { spawn } = require('child_process')
const pigz = { createGzip: () => es.child(spawn(`pigz`, ['-c'])) }
fastify.register(compressPlugin, { global: false, zlib: pigz })
```

Inflating compressed content is a convenience feature for services interfacing with clients like `curl`, or embedded devices, especially in a mesh scenario where data is produced and consumed deflated until it hits the edge. That said, I recognize it adds an extra stream between `reply.send` and the network interface, so I'd be down for making it opt-in.