### PR TITLE
Remove "missing payload" warning in onSend hook

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,7 +77,6 @@ function compressPlugin (fastify, opts, next) {
 
   function onSend (req, reply, payload, next) {
     if (payload == null) {
-      reply.res.log.warn('compress: missing payload')
       return next()
     }
 


### PR DESCRIPTION
In onSend hook, there's no reason to warn when there's no payload. It's valid to send stuff without payload, like a redirect, even when using fastify-compress in global mode.

close #37 