### PR TITLE
This closes issue #58

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This plugin add a `compress` function to `reply` that accepts a stream or a stri
 
 ```javascript
 const fs = require('fs')
-const fastify = require('fastify')
+const fastify = require('fastify')()
 
 fastify.register(require('fastify-compress'), { global: false })
 


### PR DESCRIPTION
fastify.register(require('fastify-compress'), { global: false })
        ^
TypeError: fastify.register is not a function