### PR TITLE
Add support for quality values

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Fastify compression utils",
   "main": "index.js",
   "dependencies": {
+    "encoding-negotiator": "^2.0.0",
     "fastify-plugin": "^1.0.0",
     "into-stream": "4.0.0",
     "is-deflate": "^1.0.0",


### PR DESCRIPTION
This adds support for quality values in the `accept-encoding` header.

Closes #70 