### PR TITLE
Greenkeeper/minipass 2.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "is-stream": "^2.0.0",
     "is-zip": "^1.0.0",
     "mime-db": "^1.33.0",
-    "minipass": "2.9.0",
+    "minipass": "^2.9.0",
     "peek-stream": "^1.1.0",
     "pump": "^3.0.0",
     "pumpify": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "is-stream": "^2.0.0",
     "is-zip": "^1.0.0",
     "mime-db": "^1.33.0",
-    "minipass": "2.5.1",
+    "minipass": "2.9.0",
     "peek-stream": "^1.1.0",
     "pump": "^3.0.0",
     "pumpify": "^2.0.0",


### PR DESCRIPTION
There is no reasons to lock this dep.
Introduced here: https://github.com/fastify/fastify-compress/commit/3249c8ea1639cc37d5c077c9f0287f901de02408

Closes #81 