### PR TITLE
Allow customizing used encodings

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,41 +4,41 @@
 
 [![Build Status](https://travis-ci.org/fastify/fastify-compress.svg?branch=master)](https://travis-ci.org/fastify/fastify-compress) [![js-standard-style](https://img.shields.io/badge/code%20style-standard-brightgreen.svg?style=flat)](http://standardjs.com/)
 
-Adds compression utils to the Fastify `reply` object.  
-Support `gzip`, `deflate` and `brotli`.
+Adds compression utils to [the Fastify `reply` object](https://www.fastify.io/docs/master/Reply/).  
+Supports `gzip`, `deflate`, and `brotli`.
 
 ## Install
 ```
-npm i fastify-compress --save
+npm i fastify-compress
 ```
 
 ## Usage
-This plugins adds two functionalities to Fastify, a compress utility and a global compression hook.
+This plugin adds two functionalities to Fastify: a compress utility and a global compression hook.
 
-Currently the following headers are supported:
-- `'deflate'`
-- `'gzip'`
-- `'br'`
-- `'*'`
+Currently, the following encoding tokens are supported, using the first acceptable token in this order:
 
-If the `'accept-encoding'` header specifies no preferred encoding with an asterisk `*` the payload will be compressed with `gzip`.
+1. `br`
+2. `gzip`
+3. `deflate`
+4. `*` (no preference — `fastify-compress` will use `gzip`)
+5. `identity` (no compression)
 
-If an unsupported encoding is received, it will automatically return a `406` error, if the `'accept-encoding'` header is missing, it will not compress the payload.
+If the `accept-encoding` header is missing, it will not compress the payload. If `accept-encoding` is present but no supported encoding is found, a `406` error is returned.
 
-It automatically defines if a payload should be compressed or not based on its `Content-Type`, if no content type is present, it will assume is `application/json`.
+The plugin automatically decides if a payload should be compressed based on its `content-type`; if no content type is present, it will assume `application/json`.
 
 ### Global hook
-The global compression hook is enabled by default if you want to disable it, pass the option `{ global: false }`.
+The global compression hook is enabled by default. To disable it, pass the option `{ global: false }`:
 ```javascript
 fastify.register(
   require('fastify-compress'),
   { global: false }
 )
 ```
-Remember that thanks to the Fastify encapsulation model, you can set a global compression, but running it only in a subset of routes is you wrap them inside a plugin.
+Remember that thanks to the Fastify encapsulation model, you can set a global compression, but run it only in a subset of routes if you wrap them inside a plugin.
 
 ### `reply.compress`
-This plugin add a `compress` function to `reply` that accepts a stream or a string and compress it based on the `'accept-encoding'` header. If a js object is passed in, will be stringified as json.  
+This plugin adds a `compress` method to `reply` that accepts a stream or a string, and compresses it based on the `accept-encoding` header. If a JS object is passed in, it will be stringified to JSON.  
 
 ```javascript
 const fs = require('fs')
@@ -59,7 +59,7 @@ fastify.listen(3000, function (err) {
 ```
 ## Options
 ### Threshold
-You can set a custom threshold below which it will not be made compression, default to `1024`.
+The minimum byte size for a response to be compressed. Defaults to `1024`.
 ```javascript
 fastify.register(
   require('fastify-compress'),
@@ -67,7 +67,7 @@ fastify.register(
 )
 ```
 ### customTypes
-[mime-db](https://github.com/jshttp/mime-db) is used to determine if a `Content-Type` should be compressed. You can compress additional content types via regular expression.
+[mime-db](https://github.com/jshttp/mime-db) is used to determine if a `content-type` should be compressed. You can compress additional content types via regular expression.
 ```javascript
 fastify.register(
   require('fastify-compress'),
@@ -75,9 +75,9 @@ fastify.register(
 )
 ```
 ### Brotli
-Brotli compression is enabled by default if your Node.js(>= v11.7.0) supports it natively.
+Brotli compression is enabled by default if your Node.js supports it natively (≥ v11.7.0).
 
-For the Node.js versions that not support brotli natively, it's not enabled by default, if you need it we recommend to install [`iltorb`](https://www.npmjs.com/package/iltorb) and pass it as option.
+For Node.js versions that don’t natively support Brotli, it's not enabled by default. If you need it, we recommend installing [`iltorb`](https://www.npmjs.com/package/iltorb) and passing it to the `brotli` option:
 
 ```javascript
 fastify.register(
@@ -87,10 +87,10 @@ fastify.register(
 ```
 
 ### Disable compression by header
-You can selectively disable the response compression by using the `x-no-compression` header in the request.
+You can selectively disable response compression by using the `x-no-compression` header in the request.
 
 ### Inflate pre-compressed bodies for clients that do not support compression
-Optional feature to inflate pre-compressed data if the client doesn't include one of the supported compression types in its `Accept-Encoding` header.
+Optional feature to inflate pre-compressed data if the client doesn't include one of the supported compression types in its `accept-encoding` header.
 ```javascript
 fastify.register(
   require('fastify-compress'),
@@ -103,8 +103,20 @@ fastify.get('/file', (req, reply) =>
   reply.send(fs.createReadStream('./file.gz')))
 ```
 
+### Customize encoding priority
+
+By default, `fastify-compress` prioritizes compression as described [at the beginning of §Usage](#usage). You can change that by passing an array of compression tokens to the `encodings` option:
+
+```javascript
+fastify.register(
+  require('fastify-compress'),
+  // Only support gzip and deflate, and prefer deflate to gzip
+  { encodings: ['deflate', 'gzip'] }
+)
+```
+
 ## Note
-Please have in mind that in large scale scenarios, you should use a proxy like Nginx to handle response-compression.
+Please note that in large-scale scenarios, you should use a proxy like Nginx to handle response compression.
 
 ## Acknowledgements
 This project is kindly sponsored by:

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,8 @@
 import { Plugin } from 'fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
 
+type EncodingToken = 'br' | 'deflate' | 'gzip' | 'identity'
+
 declare const fastifyCompress: Plugin<
   Server,
   IncomingMessage,
@@ -12,6 +14,7 @@ declare const fastifyCompress: Plugin<
     brotli?: NodeModule
     zlib?: NodeModule
     inflateIfDeflated?: boolean
+    encodings?: Array<EncodingToken>
   }
 >
 

--- a/index.js
+++ b/index.js
@@ -153,7 +153,7 @@ function onEnd (err) {
   if (err) this.res.log.error(err)
 }
 
-function getEncodingHeader (supportedEncodings, request) {
+function getEncodingHeader (encodings, request) {
   let header = request.headers['accept-encoding']
   if (header != null) {
     header = header.toLowerCase()

--- a/index.js
+++ b/index.js
@@ -44,7 +44,7 @@ function compressPlugin (fastify, opts, next) {
   }
 
   if (opts.encodings && opts.encodings.length < 1) {
-    throw Error('The `encodings` array option must have at least 1 item.')
+    next(new Error('The `encodings` option array must have at least 1 item.'))
   }
 
   const encodings = Array.isArray(opts.encodings)
@@ -52,6 +52,10 @@ function compressPlugin (fastify, opts, next) {
       .filter(encoding => opts.encodings.includes(encoding))
       .sort((a, b) => opts.encodings.indexOf(a) - supportedEncodings.indexOf(b))
     : supportedEncodings
+
+  if (encodings.length < 1) {
+    next(new Error('None of the passed `encodings` were supported — compression not possible.'))
+  }
 
   next()
 

--- a/index.js
+++ b/index.js
@@ -43,6 +43,10 @@ function compressPlugin (fastify, opts, next) {
     supportedEncodings.unshift('br')
   }
 
+  if (opts.encodings && opts.encodings.length < 1) {
+    throw Error('The `encodings` array option must have at least 1 item.')
+  }
+
   const encodings = Array.isArray(opts.encodings)
     ? supportedEncodings
       .filter(encoding => opts.encodings.includes(encoding))
@@ -169,7 +173,8 @@ function closeStream (payload) {
 }
 
 function getEncodingHeader (encodings, request) {
-  const header = (request.headers['accept-encoding'] || '').replace('*', 'gzip')
+  const header = (request.headers['accept-encoding'] || '')
+    .replace('*', 'gzip') // consider the no-preference token as gzip for downstream compat
   return encodingNegotiator.negotiate(header, encodings)
 }
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "compression",
     "deflate",
     "gzip",
-    "brodli"
+    "brotli"
   ],
   "author": "Tomas Della Vedova - @delvedor (http://delved.org)",
   "license": "MIT",

--- a/test/test.js
+++ b/test/test.js
@@ -1410,7 +1410,12 @@ test('Should only use `encodings` if passed', t => {
 })
 
 test('Should error if `encodings` array is empty', t => {
+  t.plan(1)
   const fastify = Fastify()
+
   fastify.register(compressPlugin, { encodings: [] })
-  fastify.ready(err => { t.ok(err instanceof Error) })
+
+  fastify.ready(err => {
+    t.ok(err instanceof Error)
+  })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -1409,11 +1409,8 @@ test('Should only use `encodings` if passed', t => {
   })
 })
 
-test('Should throw if `encodings` array is empty', t => {
+test('Should error if `encodings` array is empty', t => {
   const fastify = Fastify()
-
-  t.throws(
-    fastify.register(compressPlugin, { encodings: [] }),
-    {}
-  )
+  fastify.register(compressPlugin, { encodings: [] })
+  fastify.ready(err => { t.ok(err instanceof Error) })
 })

--- a/test/test.js
+++ b/test/test.js
@@ -258,7 +258,7 @@ test('should follow the encoding order', t => {
     url: '/',
     method: 'GET',
     headers: {
-      'accept-encoding': 'hello,br'
+      'accept-encoding': 'hello,br,gzip'
     }
   }, (err, res) => {
     t.error(err)
@@ -1385,4 +1385,35 @@ test('Should not apply customTypes if value passed is not RegExp', t => {
     t.notOk(res.headers['content-encoding'])
     t.strictEqual(res.statusCode, 200)
   })
+})
+
+test('Should only use `encodings` if passed', t => {
+  t.plan(3)
+  const fastify = Fastify()
+  fastify.register(compressPlugin, { encodings: ['deflate'] })
+
+  fastify.get('/', (req, reply) => {
+    reply.send(createReadStream('./package.json'))
+  })
+
+  fastify.inject({
+    url: '/',
+    method: 'GET',
+    headers: {
+      'accept-encoding': 'br,gzip,deflate'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.headers['content-encoding'], 'deflate')
+    t.strictEqual(res.statusCode, 200)
+  })
+})
+
+test('Should throw if `encodings` array is empty', t => {
+  const fastify = Fastify()
+
+  t.throws(
+    fastify.register(compressPlugin, { encodings: [] }),
+    {}
+  )
 })

--- a/test/test.js
+++ b/test/test.js
@@ -1481,8 +1481,8 @@ test('Should error if no entries in `encodings` are supported', t => {
   t.plan(1)
   const fastify = Fastify()
 
-  fastify.register(compressPlugin, { 
-    encodings: ['(not-a-real-encoding)'] 
+  fastify.register(compressPlugin, {
+    encodings: ['(not-a-real-encoding)']
   })
 
   fastify.ready(err => {

--- a/test/test.js
+++ b/test/test.js
@@ -1419,3 +1419,16 @@ test('Should error if `encodings` array is empty', t => {
     t.ok(err instanceof Error)
   })
 })
+
+test('Should error if no entries in `encodings` are supported', t => {
+  t.plan(1)
+  const fastify = Fastify()
+
+  fastify.register(compressPlugin, { 
+    encodings: ['(not-a-real-encoding)'] 
+  })
+
+  fastify.ready(err => {
+    t.ok(err instanceof Error)
+  })
+})

--- a/test/types/index.ts
+++ b/test/types/index.ts
@@ -12,5 +12,6 @@ app.register(fastifyCompress, {
   brotli: iltorb,
   zlib: zlib,
   inflateIfDeflated: true,
-  customTypes: /x-protobuf$/
+  customTypes: /x-protobuf$/,
+  encodings: ['gzip', 'br', 'identity', 'deflate']
 })


### PR DESCRIPTION
While implementing the option to choose the order of accepted encodings, it was less code and more elegant to also let consumers avoid certain encodings entirely. This would be useful in the case of misbehaving downstream boxes.

Also changes default priority to prefer Brotli to gzip.

Fixes #61, fixes #43, closes #62.

## Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
