### PR TITLE
Remove HTTP406 errors, allow variable case in accept encoding header to align with RFC 7231

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Currently the following headers are supported:
 
 If the `'accept-encoding'` header specifies no preferred encoding with an asterisk `*` the payload will be compressed with `gzip`.
 
-If an unsupported encoding is received, it will automatically return a `406` error, if the `'accept-encoding'` header is missing, it will not compress the payload.
+If an unsupported encoding is received or if the `'accept-encoding'` header is missing, it will not compress the payload.
 
 It automatically defines if a payload should be compressed or not based on its `Content-Type`, if no content type is present, it will assume is `application/json`.
 


### PR DESCRIPTION
Fixes #85 

#### Checklist

- [Ran test, benchmark is not a script] run `npm run test` and `npm run benchmark`
- [Tests succeeded] tests and/or benchmarks are included
- [Yes] documentation is changed or added
- [YES] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
