### PR TITLE
Allowing custom error messaging on unsupported encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,12 +87,12 @@ fastify.register(
 ```
 
 ### onUnsupportedEncoding
-When the encoding is not supported, a custom error response can be sent in place of the uncompressed payload by setting the `onUnsupportedEncoding(encoding, reply)` option to be a function that can modify the reply and return a `string | Buffer | Stream | Error` payload.
+When the encoding is not supported, a custom error response can be sent in place of the uncompressed payload by setting the `onUnsupportedEncoding(encoding, request, reply)` option to be a function that can modify the reply and return a `string | Buffer | Stream | Error` payload.
 ```javascript
 fastify.register(
   require('fastify-compress'),
   {
-    onUnsupportedEncoding: (encoding, reply) => {
+    onUnsupportedEncoding: (encoding, request, reply) => {
       reply.code(406)
       return 'We do not support the ' + encoding + ' encoding.'
     }

--- a/README.md
+++ b/README.md
@@ -23,18 +23,7 @@ Currently the following headers are supported:
 
 If the `'accept-encoding'` header specifies no preferred encoding with an asterisk `*` the payload will be compressed with `gzip`.
 
-If an unsupported encoding is received or if the `'accept-encoding'` header is missing, it will not compress the payload. If an unsupported encoding is recieved, a custom error response can be sent in place of the uncompressed payload by setting the `onUnsupportedEncoding(encoding, reply)` option to be a function that can modify the reply and return a `string | Buffer | Stream | Error` payload.
-```javascript
-fastify.register(
-  require('fastify-compress'),
-  {
-    onUnsupportedEncoding: (encoding, reply) => {
-      reply.code(406)
-      return 'We do not support the ' + encoding + ' encoding.'
-    }
-  }
-)
-```
+If an unsupported encoding is recieved or if the `'accept-encoding'` header is missing, it will not compress the payload. If an unsupported encoding is recieved and you would like to return an error, provide an `onUnsupportedEncoding` option.
 
 It automatically defines if a payload should be compressed or not based on its `Content-Type`, if no content type is present, it will assume is `application/json`.
 
@@ -94,6 +83,20 @@ For the Node.js versions that not support brotli natively, it's not enabled by d
 fastify.register(
   require('fastify-compress'),
   { brotli: require('iltorb') }
+)
+```
+
+### onUnsupportedEncoding
+When the encoding is not supported, a custom error response can be sent in place of the uncompressed payload by setting the `onUnsupportedEncoding(encoding, reply)` option to be a function that can modify the reply and return a `string | Buffer | Stream | Error` payload.
+```javascript
+fastify.register(
+  require('fastify-compress'),
+  {
+    onUnsupportedEncoding: (encoding, reply) => {
+      reply.code(406)
+      return 'We do not support the ' + encoding + ' encoding.'
+    }
+  }
 )
 ```
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Currently the following headers are supported:
 
 If the `'accept-encoding'` header specifies no preferred encoding with an asterisk `*` the payload will be compressed with `gzip`.
 
-If an unsupported encoding is received or if the `'accept-encoding'` header is missing, it will not compress the payload. A custom response can be sent instead by setting the `onUnsupportedEncoding(encoding, reply)` option to be a function that can modify the reply and return a `string | Buffer | Stream | Error` payload.
+If an unsupported encoding is received or if the `'accept-encoding'` header is missing, it will not compress the payload. If an unsupported encoding is recieved, a custom error response can be sent in place of the uncompressed payload by setting the `onUnsupportedEncoding(encoding, reply)` option to be a function that can modify the reply and return a `string | Buffer | Stream | Error` payload.
 ```javascript
 fastify.register(
   require('fastify-compress'),

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Currently the following headers are supported:
 
 If the `'accept-encoding'` header specifies no preferred encoding with an asterisk `*` the payload will be compressed with `gzip`.
 
-If an unsupported encoding is received, it will automatically return a `406` error, if the `'accept-encoding'` header is missing, it will not compress the payload.
+If an unsupported encoding is received or if the `'accept-encoding'` header is missing, it will not compress the payload.
 
 It automatically defines if a payload should be compressed or not based on its `Content-Type`, if no content type is present, it will assume is `application/json`.
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,18 @@ Currently the following headers are supported:
 
 If the `'accept-encoding'` header specifies no preferred encoding with an asterisk `*` the payload will be compressed with `gzip`.
 
-If an unsupported encoding is received or if the `'accept-encoding'` header is missing, it will not compress the payload.
+If an unsupported encoding is received or if the `'accept-encoding'` header is missing, it will not compress the payload. A custom response can be sent instead by setting the `onUnsupportedEncoding(encoding, reply)` option to be a function that can modify the reply and return a `string | Buffer | Stream | Error` payload.
+```javascript
+fastify.register(
+  require('fastify-compress'),
+  {
+    onUnsupportedEncoding: (encoding, reply) => {
+      reply.code(406)
+      return 'We do not support the ' + encoding + ' encoding.'
+    }
+  }
+)
+```
 
 It automatically defines if a payload should be compressed or not based on its `Content-Type`, if no content type is present, it will assume is `application/json`.
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,5 +1,6 @@
-import { Plugin } from 'fastify'
+import { Plugin, FastifyReply } from 'fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
+import { Stream } from 'stream';
 
 declare const fastifyCompress: Plugin<
   Server,
@@ -12,6 +13,7 @@ declare const fastifyCompress: Plugin<
     brotli?: NodeModule
     zlib?: NodeModule
     inflateIfDeflated?: boolean
+    onUnsupportedEncoding?: (encoding: string, reply: FastifyReply<ServerResponse>) => string | Buffer | Stream | Error
   }
 >
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-import { Plugin, FastifyReply } from 'fastify'
+import { Plugin, FastifyReply, FastifyRequest } from 'fastify'
 import { Server, IncomingMessage, ServerResponse } from 'http'
 import { Stream } from 'stream';
 
@@ -15,7 +15,7 @@ declare const fastifyCompress: Plugin<
     brotli?: NodeModule
     zlib?: NodeModule
     inflateIfDeflated?: boolean
-    onUnsupportedEncoding?: (encoding: string, reply: FastifyReply<ServerResponse>) => string | Buffer | Stream | Error
+    onUnsupportedEncoding?: (encoding: string, reply: FastifyReply<ServerResponse>, request: FastifyRequest<ServerResponse>) => string | Buffer | Stream | Error
     encodings?: Array<EncodingToken>
   }
 >

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ declare const fastifyCompress: Plugin<
     brotli?: NodeModule
     zlib?: NodeModule
     inflateIfDeflated?: boolean
-    onUnsupportedEncoding?: (encoding: string, request: FastifyRequest<ServerResponse>, reply: FastifyReply<ServerResponse>) => string | Buffer | Stream | Error
+    onUnsupportedEncoding?: (encoding: string, request: FastifyRequest<ServerResponse>, reply: FastifyReply<ServerResponse>) => string | Buffer | Stream
     encodings?: Array<EncodingToken>
   }
 >

--- a/index.d.ts
+++ b/index.d.ts
@@ -15,7 +15,7 @@ declare const fastifyCompress: Plugin<
     brotli?: NodeModule
     zlib?: NodeModule
     inflateIfDeflated?: boolean
-    onUnsupportedEncoding?: (encoding: string, reply: FastifyReply<ServerResponse>, request: FastifyRequest<ServerResponse>) => string | Buffer | Stream | Error
+    onUnsupportedEncoding?: (encoding: string, request: FastifyRequest<ServerResponse>, reply: FastifyReply<ServerResponse>) => string | Buffer | Stream | Error
     encodings?: Array<EncodingToken>
   }
 >

--- a/index.js
+++ b/index.js
@@ -78,7 +78,13 @@ function compressPlugin (fastify, opts, next) {
 
     if (encoding == null && onUnsupportedEncoding != null) {
       var encodingHeader = this.request.headers['accept-encoding']
-      var errorPayload = onUnsupportedEncoding(encodingHeader, this.request, this)
+
+      var errorPayload
+      try {
+        errorPayload = onUnsupportedEncoding(encodingHeader, this.request, this)
+      } catch (ex) {
+        errorPayload = ex
+      }
       return this.send(errorPayload)
     }
 
@@ -131,11 +137,11 @@ function compressPlugin (fastify, opts, next) {
 
     if (encoding == null && onUnsupportedEncoding != null) {
       var encodingHeader = req.headers['accept-encoding']
-      var errorPayload = onUnsupportedEncoding(encodingHeader, reply.request, reply)
-      if (errorPayload instanceof Error) {
-        return next(errorPayload)
-      } else {
+      try {
+        var errorPayload = onUnsupportedEncoding(encodingHeader, reply.request, reply)
         return next(null, errorPayload)
+      } catch (ex) {
+        return next(ex)
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ function compressPlugin (fastify, opts, next) {
 
     if (encoding == null && onUnsupportedEncoding != null) {
       var encodingHeader = this.request.headers['accept-encoding']
-      var errorPayload = onUnsupportedEncoding(encodingHeader, this)
+      var errorPayload = onUnsupportedEncoding(encodingHeader, this, this.request)
       return this.send(errorPayload)
     }
 
@@ -131,7 +131,7 @@ function compressPlugin (fastify, opts, next) {
 
     if (encoding == null && onUnsupportedEncoding != null) {
       var encodingHeader = req.headers['accept-encoding']
-      var errorPayload = onUnsupportedEncoding(encodingHeader, reply)
+      var errorPayload = onUnsupportedEncoding(encodingHeader, reply, reply.request)
       if (errorPayload instanceof Error) {
         return next(errorPayload)
       } else {

--- a/index.js
+++ b/index.js
@@ -140,7 +140,7 @@ function compressPlugin (fastify, opts, next) {
       try {
         var errorPayload = onUnsupportedEncoding(encodingHeader, reply.request, reply)
         return next(null, errorPayload)
-      } catch (ex) {
+      } catch (err) {
         return next(ex)
       }
     }

--- a/index.js
+++ b/index.js
@@ -141,7 +141,7 @@ function compressPlugin (fastify, opts, next) {
         var errorPayload = onUnsupportedEncoding(encodingHeader, reply.request, reply)
         return next(null, errorPayload)
       } catch (err) {
-        return next(ex)
+        return next(err)
       }
     }
 

--- a/index.js
+++ b/index.js
@@ -78,7 +78,7 @@ function compressPlugin (fastify, opts, next) {
 
     if (encoding == null && onUnsupportedEncoding != null) {
       var encodingHeader = this.request.headers['accept-encoding']
-      var errorPayload = onUnsupportedEncoding(encodingHeader, this, this.request)
+      var errorPayload = onUnsupportedEncoding(encodingHeader, this.request, this)
       return this.send(errorPayload)
     }
 
@@ -131,7 +131,7 @@ function compressPlugin (fastify, opts, next) {
 
     if (encoding == null && onUnsupportedEncoding != null) {
       var encodingHeader = req.headers['accept-encoding']
-      var errorPayload = onUnsupportedEncoding(encodingHeader, reply, reply.request)
+      var errorPayload = onUnsupportedEncoding(encodingHeader, reply.request, reply)
       if (errorPayload instanceof Error) {
         return next(errorPayload)
       } else {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "is-stream": "^2.0.0",
     "is-zip": "^1.0.0",
     "mime-db": "^1.33.0",
-    "minipass": "2.5.1",
+    "minipass": "^2.9.0",
     "peek-stream": "^1.1.0",
     "pump": "^3.0.0",
     "pumpify": "^2.0.0",

--- a/test/test.js
+++ b/test/test.js
@@ -316,6 +316,34 @@ test('should send uncompressed if unsupported encoding', t => {
   })
 })
 
+test('should call callback if unsupported encoding', t => {
+  t.plan(3)
+  const fastify = Fastify()
+  fastify.register(compressPlugin, {
+    global: false,
+    onUnsupportedEncoding: (encoding, reply) => {
+      reply.code(406)
+      return JSON.stringify({ hello: encoding })
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.type('text/plain').compress(createReadStream('./package.json'))
+  })
+
+  fastify.inject({
+    url: '/',
+    method: 'GET',
+    headers: {
+      'accept-encoding': 'hello'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 406)
+    t.deepEqual(JSON.parse(res.payload), { hello: 'hello' })
+  })
+})
+
 test('should send uncompressed if unsupported encoding with quality value', t => {
   t.plan(3)
   const fastify = Fastify()
@@ -445,7 +473,7 @@ test('Should close the stream', t => {
   })
 })
 
-test('Should send uncompressed on invalid accept encoding', t => {
+test('Should send uncompressed on invalid accept encoding - global', t => {
   t.plan(3)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: true })
@@ -465,6 +493,67 @@ test('Should send uncompressed on invalid accept encoding', t => {
     t.error(err)
     t.strictEqual(res.statusCode, 200)
     t.strictEqual(res.payload, 'something')
+  })
+})
+
+test('should call callback if unsupported encoding - global', t => {
+  t.plan(3)
+  const fastify = Fastify()
+  fastify.register(compressPlugin, {
+    global: true,
+    onUnsupportedEncoding: (encoding, reply) => {
+      reply.code(406)
+      return JSON.stringify({ hello: encoding })
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.header('content-type', 'text/plain')
+    reply.send(createReadStream('./package.json'))
+  })
+
+  fastify.inject({
+    url: '/',
+    method: 'GET',
+    headers: {
+      'accept-encoding': 'hello'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 406)
+    t.deepEqual(JSON.parse(res.payload), { hello: 'hello' })
+  })
+})
+
+test('should call callback if unsupported encoding and return error - global', t => {
+  t.plan(3)
+  const fastify = Fastify()
+  fastify.register(compressPlugin, {
+    global: true,
+    onUnsupportedEncoding: (encoding, reply) => {
+      return new Error('testing error')
+    }
+  })
+
+  fastify.get('/', (req, reply) => {
+    reply.header('content-type', 'text/plain')
+    reply.send(createReadStream('./package.json'))
+  })
+
+  fastify.inject({
+    url: '/',
+    method: 'GET',
+    headers: {
+      'accept-encoding': 'hello'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 500)
+    t.deepEqual(JSON.parse(res.payload), {
+      error: 'Internal Server Error',
+      message: 'testing error',
+      statusCode: 500
+    })
   })
 })
 

--- a/test/test.js
+++ b/test/test.js
@@ -321,7 +321,7 @@ test('should call callback if unsupported encoding', t => {
   const fastify = Fastify()
   fastify.register(compressPlugin, {
     global: false,
-    onUnsupportedEncoding: (encoding, reply) => {
+    onUnsupportedEncoding: (encoding, request, reply) => {
       reply.code(406)
       return JSON.stringify({ hello: encoding })
     }
@@ -501,7 +501,7 @@ test('should call callback if unsupported encoding - global', t => {
   const fastify = Fastify()
   fastify.register(compressPlugin, {
     global: true,
-    onUnsupportedEncoding: (encoding, reply) => {
+    onUnsupportedEncoding: (encoding, request, reply) => {
       reply.code(406)
       return JSON.stringify({ hello: encoding })
     }
@@ -530,7 +530,7 @@ test('should call callback if unsupported encoding and return error - global', t
   const fastify = Fastify()
   fastify.register(compressPlugin, {
     global: true,
-    onUnsupportedEncoding: (encoding, reply) => {
+    onUnsupportedEncoding: (encoding, request, reply) => {
       return new Error('testing error')
     }
   })


### PR DESCRIPTION
created new function in the options to allow users to specify a custom response when the encoding is unsupported.

I could not follow the original design of using the reply.send() function in the callback because you can't call that function in the onSend hook.

#### Checklist

- [X] run `npm run test` and `npm run benchmark`
- [X] tests and/or benchmarks are included
- [X] documentation is changed or added
- [X] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
