### PR TITLE
bug fix - undefined value of compressible now does not compress

### DIFF
--- a/index.js
+++ b/index.js
@@ -258,7 +258,7 @@ function shouldCompress (type, compressibleTypes) {
   if (compressibleTypes.test(type)) return true
   var data = mimedb[type.split(';', 1)[0].trim().toLowerCase()]
   if (data === undefined) return false
-  return data.compressible
+  return data.compressible == true;
 }
 
 function isCompressed (data) {

--- a/index.js
+++ b/index.js
@@ -258,7 +258,7 @@ function shouldCompress (type, compressibleTypes) {
   if (compressibleTypes.test(type)) return true
   var data = mimedb[type.split(';', 1)[0].trim().toLowerCase()]
   if (data === undefined) return false
-  return data.compressible == true;
+  return data.compressible === true
 }
 
 function isCompressed (data) {

--- a/test/test-global.js
+++ b/test/test-global.js
@@ -1611,3 +1611,26 @@ test('Should error if no entries in `encodings` are supported', t => {
     t.ok(err instanceof Error)
   })
 })
+
+test('Should not compress mime types with undefined compressible values', t => {
+  t.plan(4)
+  const fastify = Fastify()
+  fastify.register(compressPlugin, { brotli, threshold: 0 })
+
+  fastify.get('/', (req, reply) => {
+    reply.type('image/webp').send('hello')
+  })
+
+  fastify.inject({
+    url: '/',
+    method: 'GET',
+    headers: {
+      'accept-encoding': 'gzip, deflate, br'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.strictEqual(res.statusCode, 200)
+    t.notOk(res.headers['content-encoding'])
+    t.strictEqual(res.payload, 'hello')
+  })
+})


### PR DESCRIPTION
https://github.com/jshttp/mime-db package has many content type for which the value of `compressible` is undefined. When this is encountered, this package was wrongly compressing those mime types. One such example is `image/webp` type.

This PR fixes that wrong behavior and also adds test to prevent it from happening again in future.

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
