### PR TITLE
Support passing zlibOptions and brotliOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,6 +144,24 @@ fastify.register(
 )
 ```
 
+### brotliOptions and zlibOptions
+
+You can tune compression by setting the `brotliOptions` and `zlibOptions` properties. These properties are passed directly to native node `zlib` methods, so they should match the corresponding [class](https://nodejs.org/api/zlib.html#zlib_class_brotlioptions) [definitions](https://nodejs.org/api/zlib.html#zlib_class_options).
+
+```javascript
+  server.register(fastifyCompress, {
+    brotliOptions: {
+      params: {
+        [zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT, // useful for APIs that primarily return text
+        [zlib.constants.BROTLI_PARAM_QUALITY]: 4, // default is 11, max is 11, min is 0
+      },
+    },
+    zlibOptions: {
+      level: 9, // default is 9, max is 9, min is 0
+    }
+  });
+```
+
 ## Usage - Decompress request payloads
 
 This plugin adds a `preParsing` hook that decompress the request payload according to the `content-encoding` request header.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,9 +1,10 @@
 import { FastifyPlugin, FastifyReply, FastifyRequest, RawServerBase } from 'fastify';
 import { Input, InputObject } from 'into-stream';
 import { Stream } from 'stream';
+import { BrotliOptions, ZlibOptions } from 'zlib';
 
 declare module "fastify" {
-  interface FastifyReplyInterface {
+  interface FastifyReply {
     compress(input: Stream | Input | InputObject): void;
   }
 }
@@ -15,6 +16,8 @@ export interface FastifyCompressOptions {
   threshold?: number
   customTypes?: RegExp
   zlib?: NodeModule
+  brotliOptions?: BrotliOptions
+  zlibOptions?: ZlibOptions
   inflateIfDeflated?: boolean
   onUnsupportedEncoding?: (encoding: string, request: FastifyRequest<RawServerBase>, reply: FastifyReply<RawServerBase>) => string | Buffer | Stream
   encodings?: Array<EncodingToken>

--- a/index.js
+++ b/index.js
@@ -323,7 +323,6 @@ function buildRouteDecompress (fastify, params, routeOptions) {
 function compress (params) {
   return function (payload) {
     if (payload == null) {
-      this.log.debug('compress: missing payload')
       this.send(new Error('Internal server error'))
       return
     }

--- a/index.js
+++ b/index.js
@@ -110,19 +110,21 @@ function processCompressParams (opts) {
     global: (typeof opts.global === 'boolean') ? opts.global : true
   }
 
+  params.brotliOptions = opts.brotliOptions
+  params.zlibOptions = opts.zlibOptions
   params.onUnsupportedEncoding = opts.onUnsupportedEncoding
   params.inflateIfDeflated = opts.inflateIfDeflated === true
   params.threshold = typeof opts.threshold === 'number' ? opts.threshold : 1024
   params.compressibleTypes = opts.customTypes instanceof RegExp ? opts.customTypes : /^text\/|\+json$|\+text$|\+xml$|octet-stream$/
   params.compressStream = {
-    br: (opts.zlib || zlib).createBrotliCompress || zlib.createBrotliCompress,
-    gzip: (opts.zlib || zlib).createGzip || zlib.createGzip,
-    deflate: (opts.zlib || zlib).createDeflate || zlib.createDeflate
+    br: () => ((opts.zlib || zlib).createBrotliCompress || zlib.createBrotliCompress)(params.brotliOptions),
+    gzip: () => ((opts.zlib || zlib).createGzip || zlib.createGzip)(params.zlibOptions),
+    deflate: () => ((opts.zlib || zlib).createDeflate || zlib.createDeflate)(params.zlibOptions)
   }
   params.uncompressStream = {
-    br: (opts.zlib || zlib).createBrotliDecompress || zlib.createBrotliDecompress,
-    gzip: (opts.zlib || zlib).createGunzip || zlib.createGunzip,
-    deflate: (opts.zlib || zlib).createInflate || zlib.createInflate
+    br: () => ((opts.zlib || zlib).createBrotliDecompress || zlib.createBrotliDecompress)(params.brotliOptions),
+    gzip: () => ((opts.zlib || zlib).createGunzip || zlib.createGunzip)(params.zlibOptions),
+    deflate: () => ((opts.zlib || zlib).createInflate || zlib.createInflate)(params.zlibOptions)
   }
 
   const supportedEncodings = ['br', 'gzip', 'deflate', 'identity']

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@types/node": "^14.0.1",
     "@typescript-eslint/parser": "^3.0.0",
     "eslint-plugin-typescript": "^0.14.0",
-    "fastify": "^3.0.0-rc.3",
+    "fastify": "^3.0.0-rc.4",
     "jsonstream": "^1.0.3",
     "pre-commit": "^1.2.2",
     "standard": "^14.3.1",

--- a/test/index.test-d.ts
+++ b/test/index.test-d.ts
@@ -10,6 +10,13 @@ app.register(fastifyCompress, {
   global: true,
   threshold: 10,
   zlib: zlib,
+  brotliOptions: {
+    params: {
+      [zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT,
+      [zlib.constants.BROTLI_PARAM_QUALITY]: 4
+    }
+  },
+  zlibOptions: { level: 1 },
   inflateIfDeflated: true,
   customTypes: /x-protobuf$/,
   encodings: ['gzip', 'br', 'identity', 'deflate'],
@@ -17,7 +24,7 @@ app.register(fastifyCompress, {
   forceRequestEncoding: 'gzip'
 })
 
-const appWithoutGlobal = fastify();
+const appWithoutGlobal = fastify()
 
 appWithoutGlobal.register(fastifyCompress, { global: false })
 


### PR DESCRIPTION
https://github.com/fastify/fastify-compress/issues/106

This does not include tests or a benchmark - just wanted to quickly throw together a first-step in the direction of completing this issue: https://github.com/fastify/fastify-compress/issues/106

This also does not include documentation, simple example is as follows:

```
  server.register(fastifyCompress, {
    brotliOptions: {
      params: {
        [zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT, // useful for APIs that primarily return text
        [zlib.constants.BROTLI_PARAM_QUALITY]: 4, // default is 11, max is 11, min is 0
      },
    },
    zlibOptions: {
      level: 9, // default is 9, max is 9, min is 0
    }
  });
```

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
