### PR TITLE
fix logger reference in onEnd

### DIFF
--- a/index.js
+++ b/index.js
@@ -382,7 +382,7 @@ function compress (params) {
 }
 
 function onEnd (err) {
-  if (err) this.raw.log.error(err)
+  if (err) this.log.error(err)
 }
 
 function trackEncodedLength (chunk) {


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Tip: `npm run bench` to compare branches interactively.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md
-->

This PR fixes following crash bug in onEnd handler:

```
webpack-internal:///../../node_modules/fastify-compress/index.js:396
    this.raw.log.error(err);
                 ^

TypeError: Cannot read property 'error' of undefined
    at _Reply.onEnd (webpack-internal:///../../node_modules/fastify-compress/index.js:396:18)
    at eval (webpack-internal:///../../node_modules/pump/index.js:75:7)
    at f (webpack-internal:///../../node_modules/once/once.js:25:25)
    at Duplexify.eval (webpack-internal:///../../node_modules/pump/index.js:31:21)
    at Duplexify.f (webpack-internal:///../../node_modules/once/once.js:25:25)
    at onclosenexttick (webpack-internal:///../../node_modules/end-of-stream/index.js:54:73)
    at processTicksAndRejections (internal/process/task_queues.js:75:11)
```

related:
- Removed modifyCoreObjects option, https://github.com/fastify/fastify/pull/2015

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows [Code of conduct](https://github.com/fastify/fastify/blob/master/CODE_OF_CONDUCT.md)
