### PR TITLE
fix: prevent compressing text/event-stream

### DIFF
--- a/index.js
+++ b/index.js
@@ -115,7 +115,7 @@ function processCompressParams (opts) {
   params.onUnsupportedEncoding = opts.onUnsupportedEncoding
   params.inflateIfDeflated = opts.inflateIfDeflated === true
   params.threshold = typeof opts.threshold === 'number' ? opts.threshold : 1024
-  params.compressibleTypes = opts.customTypes instanceof RegExp ? opts.customTypes : /^text\/|\+json$|\+text$|\+xml$|octet-stream$/
+  params.compressibleTypes = opts.customTypes instanceof RegExp ? opts.customTypes : /^text\/(?!event-stream)|\+json$|\+text$|\+xml$|octet-stream$/
   params.compressStream = {
     br: () => ((opts.zlib || zlib).createBrotliCompress || zlib.createBrotliCompress)(params.brotliOptions),
     gzip: () => ((opts.zlib || zlib).createGzip || zlib.createGzip)(params.zlibOptions),


### PR DESCRIPTION
Server-sent events (SSE) are designed to be realtime; by enabling the compression plugin on this content type the latency between writing data to the stream and receiving it on the client can be indefinitely long. This PR prevents compression on event streams, leading to SSE behaving as expected.

This change was provided via the GitHub interface, so I'm hoping that the tests/benchmarks are ran by your CI.

```
> /^text\/|\+json$|\+text$|\+xml$|octet-stream$/.test('text/event-stream')
true
> /^text\/(?!event-stream)|\+json$|\+text$|\+xml$|octet-stream$/.test('text/event-stream')
false
> /^text\/(?!event-stream)|\+json$|\+text$|\+xml$|octet-stream$/.test('text/plain')
true
```

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
