### PR TITLE
Added Vary header to all responses

### DIFF
--- a/test/test-global-compress.js
+++ b/test/test-global-compress.js
@@ -247,7 +247,7 @@ test('should send a gzipped data for * header', t => {
 })
 
 test('should send a brotli data', t => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false })
 
@@ -263,6 +263,7 @@ test('should send a brotli data', t => {
     }
   }, (err, res) => {
     t.error(err)
+    t.strictEqual(res.headers.vary, 'accept-encoding')
     t.strictEqual(res.headers['content-encoding'], 'br')
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.brotliDecompressSync(res.rawPayload)
@@ -295,7 +296,7 @@ test('should follow the encoding order', t => {
 })
 
 test('should send uncompressed if unsupported encoding', t => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false })
 
@@ -311,6 +312,7 @@ test('should send uncompressed if unsupported encoding', t => {
     }
   }, (err, res) => {
     t.error(err)
+    t.strictEqual(res.headers.vary, 'accept-encoding')
     t.strictEqual(res.statusCode, 200)
     const file = readFileSync('./package.json', 'utf8')
     t.strictEqual(res.payload, file)
@@ -318,7 +320,7 @@ test('should send uncompressed if unsupported encoding', t => {
 })
 
 test('should call callback if unsupported encoding', t => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
   fastify.register(compressPlugin, {
     global: false,
@@ -341,6 +343,7 @@ test('should call callback if unsupported encoding', t => {
   }, (err, res) => {
     t.error(err)
     t.strictEqual(res.statusCode, 406)
+    t.strictEqual(res.headers.vary, 'accept-encoding')
     t.deepEqual(JSON.parse(res.payload), { hello: 'hello' })
   })
 })
@@ -378,7 +381,7 @@ test('should call callback if unsupported encoding and throw error', t => {
 })
 
 test('should send uncompressed if unsupported encoding with quality value', t => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false })
 
@@ -394,6 +397,7 @@ test('should send uncompressed if unsupported encoding with quality value', t =>
     }
   }, (err, res) => {
     t.error(err)
+    t.strictEqual(res.headers.vary, 'accept-encoding')
     t.strictEqual(res.statusCode, 200)
     const file = readFileSync('./package.json', 'utf8')
     t.strictEqual(res.payload, file)
@@ -401,7 +405,7 @@ test('should send uncompressed if unsupported encoding with quality value', t =>
 })
 
 test('should not compress on missing header', t => {
-  t.plan(3)
+  t.plan(4)
   const fastify = Fastify()
   fastify.register(compressPlugin, { global: false })
 
@@ -414,6 +418,7 @@ test('should not compress on missing header', t => {
     method: 'GET'
   }, (err, res) => {
     t.error(err)
+    t.strictEqual(res.headers.vary, 'accept-encoding')
     t.strictEqual(res.statusCode, 200)
     t.notOk(res.headers['content-encoding'])
   })


### PR DESCRIPTION
[bug] While replying with brotly encoding, vary header was missing

Since the response body differs based on the Accept-Encoding from the request header, we need to add Vary Header of "accept-encoding" to **all** responses processed with the fastify-compress library so that CDNs and other caches work properly.


<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
