### PR TITLE
fix brotli responses being double-compressed

### DIFF
--- a/index.js
+++ b/index.js
@@ -223,6 +223,11 @@ function buildRouteCompress (fastify, params, routeOptions, decorateOnly) {
     if (payload == null) {
       return next()
     }
+    const responseEncoding = reply.getHeader('Content-Encoding')
+    if (responseEncoding && responseEncoding !== 'identity') {
+      // response is already compressed
+      return next()
+    }
     setVaryHeader(reply)
 
     let stream, encoding

--- a/test/test-global-compress.js
+++ b/test/test-global-compress.js
@@ -195,16 +195,21 @@ test('should support quality syntax', t => {
   })
 })
 
-test('onSend hook should not double-compress Stream if already zipped', t => {
-  t.plan(3)
+test('onSend hook should not double-compress Stream if already gzipped', t => {
+  t.plan(4)
   const fastify = Fastify()
-  fastify.register(compressPlugin, { global: true })
+  fastify.register(compressPlugin, {
+    global: true,
+    threshold: 0
+  })
 
+  const file = readFileSync('./package.json', 'utf8')
   fastify.get('/', (req, reply) => {
-    reply.type('text/plain').compress(
-      createReadStream('./package.json')
-        .pipe(zlib.createGzip())
-    )
+    const payload = zlib.gzipSync(file)
+    reply.type('application/json')
+      .header('content-encoding', 'gzip')
+      .header('content-length', payload.length)
+      .send(payload)
   })
 
   fastify.inject({
@@ -216,8 +221,40 @@ test('onSend hook should not double-compress Stream if already zipped', t => {
   }, (err, res) => {
     t.error(err)
     t.equal(res.headers['content-encoding'], 'gzip')
-    const file = readFileSync('./package.json', 'utf8')
+    t.equal(res.headers['content-length'], res.rawPayload.length)
     const payload = zlib.gunzipSync(res.rawPayload)
+    t.equal(payload.toString('utf-8'), file)
+  })
+})
+
+test('onSend hook should not double-compress Stream if already brotli compressed', t => {
+  t.plan(4)
+  const fastify = Fastify()
+  fastify.register(compressPlugin, {
+    global: true,
+    threshold: 0
+  })
+
+  const file = readFileSync('./package.json', 'utf8')
+  fastify.get('/', (req, reply) => {
+    const payload = zlib.brotliCompressSync(file)
+    reply.type('application/json')
+      .header('content-encoding', 'br')
+      .header('content-length', payload.length)
+      .send(payload)
+  })
+
+  fastify.inject({
+    url: '/',
+    method: 'GET',
+    headers: {
+      'accept-encoding': 'br,gzip,deflate'
+    }
+  }, (err, res) => {
+    t.error(err)
+    t.equal(res.headers['content-encoding'], 'br')
+    t.equal(res.headers['content-length'], res.rawPayload.length)
+    const payload = zlib.brotliDecompressSync(res.rawPayload)
     t.equal(payload.toString('utf-8'), file)
   })
 })


### PR DESCRIPTION
Related to https://github.com/fastify/fastify-static/pull/158

When used with fastify-static's `preCompressed` option, this plugin will double-compress `.br` files.

Currently this plugin avoids double-compressing for gzip and deflate, by inspecting the magic number in few bytes of the stream. However Brotli doesn't have a magic number to look for.

https://github.com/fastify/fastify-compress/blob/714e4a91ecf743b2bd7991b8bb9aea466992a271/index.js#L491-L494
https://github.com/fastify/fastify-compress/blob/714e4a91ecf743b2bd7991b8bb9aea466992a271/index.js#L460-L465

Instead we can check for an existing `Content-Encoding` header on the reply. This has the extra advantage that we don't need to strip off the `Content-Length` header.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [ ] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
