### PR TITLE
fix: remove zip payloads uncompress behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 Adds compression utils to [the Fastify `reply` object](https://www.fastify.io/docs/master/Reply/) and a hook to decompress requests payloads.
 Supports `gzip`, `deflate`, and `brotli`.
 
-> **Important note:** since `fastify-compress` version 4.x payloads that are compressed using the `zip` algorithm are not automatically uncompressed anymore as it is out of the scope of this plugin.
+> **Important note:** since `fastify-compress` version 4.x payloads that are compressed using the `zip` algorithm are not automatically uncompressed anymore. `fastify-compress` main feature is to provide response compression mechanism to your server, however the `zip` format does not appear in the [IANA maintained Table of Content Encodings](https://www.iana.org/assignments/http-parameters/http-parameters.xml#content-coding) and thus such behavior was out of the scope of this plugin.
 
 ## Install
 ```

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@
 Adds compression utils to [the Fastify `reply` object](https://www.fastify.io/docs/master/Reply/) and a hook to decompress requests payloads.
 Supports `gzip`, `deflate`, and `brotli`.
 
+> **Important note:** since `fastify-compress` version 4.x payloads that are compressed using the `zip` algorithm are not automatically uncompressed anymore as it is out of the scope of this plugin.
+
 ## Install
 ```
 npm i fastify-compress

--- a/index.js
+++ b/index.js
@@ -10,8 +10,6 @@ const peek = require('peek-stream')
 const Minipass = require('minipass')
 const pumpify = require('pumpify')
 const isGzip = require('is-gzip')
-const isZip = require('is-zip')
-const unZipper = require('unzipper')
 const isDeflate = require('is-deflate')
 const encodingNegotiator = require('encoding-negotiator')
 const { inherits, format } = require('util')
@@ -465,7 +463,6 @@ function shouldCompress (type, compressibleTypes) {
 function isCompressed (data) {
   if (isGzip(data)) return 1
   if (isDeflate(data)) return 2
-  if (isZip(data)) return 3
   return 0
 }
 
@@ -510,7 +507,6 @@ function unzipStream (inflate, maxRecursion) {
     switch (isCompressed(data)) {
       case 1: return swap(null, pumpify(inflate.gzip(), unzipStream(inflate, maxRecursion - 1)))
       case 2: return swap(null, pumpify(inflate.deflate(), unzipStream(inflate, maxRecursion - 1)))
-      case 3: return swap(null, pumpify(unZipper.ParseOne(), unzipStream(inflate, maxRecursion - 1)))
     }
     return swap(null, new Minipass())
   })

--- a/package.json
+++ b/package.json
@@ -17,8 +17,7 @@
     "peek-stream": "^1.1.3",
     "pump": "^3.0.0",
     "pumpify": "^2.0.1",
-    "string-to-stream": "^3.0.1",
-    "unzipper": "^0.10.11"
+    "string-to-stream": "^3.0.1"
   },
   "devDependencies": {
     "@types/node": "^16.11.10",

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -707,7 +707,7 @@ test('When `inflateIfDeflated` is `true` and `X-No-Compression` request header i
   })
 })
 
-test('it should uncompress payloads using the zip algorithm', async (t) => {
+test('it should not uncompress payloads using the zip algorithm', async (t) => {
   t.plan(4)
 
   const fastify = Fastify()

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -4,7 +4,6 @@ const { test } = require('tap')
 const { createReadStream, readFile, readFileSync } = require('fs')
 const { Readable, Writable, PassThrough } = require('stream')
 const zlib = require('zlib')
-const AdmZip = require('adm-zip')
 const JSONStream = require('jsonstream')
 const Fastify = require('fastify')
 const compressPlugin = require('../index')
@@ -704,32 +703,6 @@ test('When `inflateIfDeflated` is `true` and `X-No-Compression` request header i
     t.equal(response.statusCode, 200)
     t.notOk(response.headers['content-encoding'])
     t.same(JSON.parse('' + response.payload), json)
-  })
-
-  t.test('it should uncompress payloads using the zip algorithm', async (t) => {
-    t.plan(3)
-
-    const fastify = Fastify()
-    await fastify.register(compressPlugin, { threshold: 0, inflateIfDeflated: true })
-
-    const json = { hello: 'world' }
-    const zip = new AdmZip()
-    zip.addFile('file.zip', Buffer.from(JSON.stringify(json), 'utf-8'))
-
-    fastify.get('/', (request, reply) => {
-      reply.compress(zip.toBuffer())
-    })
-
-    const response = await fastify.inject({
-      url: '/',
-      method: 'GET',
-      headers: {
-        'x-no-compression': true
-      }
-    })
-    t.equal(response.statusCode, 200)
-    t.notOk(response.headers['content-encoding'])
-    t.same(JSON.parse(response.payload), json)
   })
 })
 


### PR DESCRIPTION
Hello.

Fix https://github.com/fastify/fastify-compress/issues/202 - this is a BREAKING-CHANGE

- Remove 2 `zip` dependencies (`is-zip` and `unzipper`)
- Remove unzipping behavior from the plugin code
- Add a test to ensure that a zipped payload is not received uncompressed

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
