### PR TITLE
feat: support Accept-Encoding token `x-gzip` as an alias for `gzip`

### DIFF
--- a/index.js
+++ b/index.js
@@ -446,7 +446,10 @@ function getEncodingHeader (encodings, request) {
   let header = request.headers['accept-encoding']
   if (header != null) {
     header = header.toLowerCase()
-      .replace(/\*/g, 'gzip') // consider the no-preference token as gzip for downstream compat
+      // consider the no-preference token as gzip for downstream compat
+      // and x-gzip as an alias of gzip
+      // ref.: [HTTP/1.1 RFC 7230 section 4.2.3](https://datatracker.ietf.org/doc/html/rfc7230#section-4.2.3)
+      .replace(/\*|x-gzip/g, 'gzip')
     return encodingNegotiator.negotiate(header, encodings)
   } else {
     return undefined

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -2294,6 +2294,33 @@ test('`Accept-Encoding` request header values :', async (t) => {
     t.equal(payload.toString('utf-8'), buf.toString())
   })
 
+  t.test('should support `gzip` alias value `x-gzip`', async (t) => {
+    t.plan(2)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true })
+
+    fastify.get('/', (request, reply) => {
+      reply
+        .type('text/plain')
+        .compress(
+          createReadStream('./package.json')
+        )
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: {
+        'accept-encoding': 'x-gzip'
+      }
+    })
+    const file = readFileSync('./package.json', 'utf8')
+    const payload = zlib.gunzipSync(response.rawPayload)
+    t.equal(response.headers['content-encoding'], 'gzip')
+    t.equal(payload.toString('utf-8'), file)
+  })
+
   t.test('should support quality syntax', async (t) => {
     t.plan(2)
 


### PR DESCRIPTION
Hello.

To ensure that this plugin is following the spec guidance, this PR aims to :
- support Accept-Encoding token `x-gzip` as an alias for `gzip` (feat)
- make sure that the `Accept-Encoding` token `x-gzip` is interpreted as an alias of `gzip` (test)

ref.: [HTTP/1.1 RFC 7230 section 4.2.3](https://datatracker.ietf.org/doc/html/rfc7230#section-4.2.3) and [IANA maintained Table of Content Encodings](https://www.iana.org/assignments/http-parameters/http-parameters.xml#content-coding)

**Note:** server-side we do not need to support this alias inside `encodings`, `requestEncodings` and `forceRequestEncoding` options (we should push good practices adoption) but client-side we should support it even though it's considered deprecated.

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
