### PR TITLE
feat: add `removeContentLengthHeader` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,21 @@ You can tune compression by setting the `brotliOptions` and `zlibOptions` proper
   });
 ```
 
+### Manage `Content-Length` header removal with removeContentLengthHeader
+By default, `fastify-compress` removes the reply `Content-Length` header. You can change that by setting the `removeContentLengthHeader` to `false` either on a global scope or on a route specific scope.
+
+```javascript
+  // Global plugin scope
+  server.register(fastifyCompress, { global: true, removeContentLengthHeader: false });
+
+  // Route specific scope
+  fastify.get('/file', {
+    compress: { removeContentLengthHeader: false }
+  }, (req, reply) =>
+    reply.compress(fs.createReadStream('./file.gz'))
+  )
+```
+
 ## Usage - Decompress request payloads
 
 This plugin adds a `preParsing` hook that decompress the request payload according to the `content-encoding` request header.


### PR DESCRIPTION
Hello.

This PR aims to :
- add a `removeContentLengthHeader` option that allows to opt-out of the automatic `Content-Length` header removal when set to `false` (set to `true` by default)
- document this new option

Fix https://github.com/fastify/fastify-compress/issues/193 use case

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
