### PR TITLE
types: add `removeContentLengthHeader` types

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -22,6 +22,7 @@ export interface FastifyCompressOptions {
   onInvalidRequestPayload?: (encoding: string, request: FastifyRequest, error: Error) => Error | undefined | null;
   onUnsupportedEncoding?: (encoding: string, request: FastifyRequest, reply: FastifyReply) => string | Buffer | Stream;
   onUnsupportedRequestEncoding?: (encoding: string, request: FastifyRequest, reply: FastifyReply) => Error | undefined | null;
+  removeContentLengthHeader: boolean;
   requestEncodings?: EncodingToken[];
   threshold?: number;
   zlib?: unknown;
@@ -34,6 +35,7 @@ interface RouteCompressOptions extends Pick<FastifyCompressOptions,
   | 'encodings'
   | 'inflateIfDeflated'
   | 'onUnsupportedEncoding'
+  | 'removeContentLengthHeader'
   | 'threshold'
   | 'zlib'
   | 'zlibOptions'

--- a/index.d.ts
+++ b/index.d.ts
@@ -22,7 +22,7 @@ export interface FastifyCompressOptions {
   onInvalidRequestPayload?: (encoding: string, request: FastifyRequest, error: Error) => Error | undefined | null;
   onUnsupportedEncoding?: (encoding: string, request: FastifyRequest, reply: FastifyReply) => string | Buffer | Stream;
   onUnsupportedRequestEncoding?: (encoding: string, request: FastifyRequest, reply: FastifyReply) => Error | undefined | null;
-  removeContentLengthHeader: boolean;
+  removeContentLengthHeader?: boolean;
   requestEncodings?: EncodingToken[];
   threshold?: number;
   zlib?: unknown;

--- a/test/types/index.test-d.ts
+++ b/test/types/index.test-d.ts
@@ -21,7 +21,8 @@ const withGlobalOptions: FastifyCompressOptions = {
   customTypes: /x-protobuf$/,
   encodings: ['gzip', 'br', 'identity', 'deflate'],
   requestEncodings: ['gzip', 'br', 'identity', 'deflate'],
-  forceRequestEncoding: 'gzip'
+  forceRequestEncoding: 'gzip',
+  removeContentLengthHeader: true
 }
 
 const app: FastifyInstance = fastify()
@@ -43,7 +44,8 @@ appWithoutGlobal.get('/one', {
   compress: {
     zlib: {
       createGzip: () => zlib.createGzip()
-    }
+    },
+    removeContentLengthHeader: false
   },
   decompress: {
     forceRequestEncoding: 'gzip',


### PR DESCRIPTION
Hello.

This PR aims to :
- add a `removeContentLengthHeader` option types and typescript tests

#### Checklist

- [x] run `npm run test` ~~and `npm run benchmark`~~
- [x] tests ~~and/or benchmarks~~ are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
