### PR TITLE
Rename module

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "fastify-compress",
-  "version": "4.0.1",
+  "name": "@fastify/compress",
+  "version": "5.0.0",
   "description": "Fastify compression utils",
   "main": "index.js",
   "types": "index.d.ts",
@@ -66,5 +66,8 @@
   },
   "tsd": {
     "directory": "test/types"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/test/global-decompress.test.js
+++ b/test/global-decompress.test.js
@@ -39,7 +39,7 @@ test('It should decompress the request payload :', async (t) => {
       payload: createPayload(zlib.createBrotliCompress)
     })
     t.equal(response.statusCode, 200)
-    t.equal(response.body, 'fastify-compress')
+    t.equal(response.body, '@fastify/compress')
   })
 
   t.test('using deflate algorithm when `Content-Encoding` request header value is set to `deflate`', async (t) => {
@@ -62,7 +62,7 @@ test('It should decompress the request payload :', async (t) => {
       payload: createPayload(zlib.createDeflate)
     })
     t.equal(response.statusCode, 200)
-    t.equal(response.body, 'fastify-compress')
+    t.equal(response.body, '@fastify/compress')
   })
 
   t.test('using gzip algorithm when `Content-Encoding` request header value is set to `gzip`', async (t) => {
@@ -85,7 +85,7 @@ test('It should decompress the request payload :', async (t) => {
       payload: createPayload(zlib.createGzip)
     })
     t.equal(response.statusCode, 200)
-    t.equal(response.body, 'fastify-compress')
+    t.equal(response.body, '@fastify/compress')
   })
 
   t.test('using the `forceRequestEncoding` provided algorithm over the `Content-Encoding` request header value', async (t) => {
@@ -108,7 +108,7 @@ test('It should decompress the request payload :', async (t) => {
       payload: createPayload(zlib.createGzip)
     })
     t.equal(response.statusCode, 200)
-    t.equal(response.body, 'fastify-compress')
+    t.equal(response.body, '@fastify/compress')
   })
 })
 
@@ -132,7 +132,7 @@ test('It should not decompress :', async (t) => {
       payload: createPayload()
     })
     t.equal(response.statusCode, 200)
-    t.equal(response.body, 'fastify-compress')
+    t.equal(response.body, '@fastify/compress')
   })
 
   t.test('when `Content-Encoding` request header value is set to `identity`', async (t) => {
@@ -155,7 +155,7 @@ test('It should not decompress :', async (t) => {
       payload: createPayload()
     })
     t.equal(response.statusCode, 200)
-    t.equal(response.body, 'fastify-compress')
+    t.equal(response.body, '@fastify/compress')
   })
 })
 

--- a/test/routes-decompress.test.js
+++ b/test/routes-decompress.test.js
@@ -55,7 +55,7 @@ test('When using routes `decompress` settings :', async (t) => {
       t.equal(usedCustomGlobal, true)
 
       t.equal(response.statusCode, 200)
-      t.equal(response.body, 'fastify-compress')
+      t.equal(response.body, '@fastify/compress')
 
       usedCustom = false
       usedCustomGlobal = false
@@ -73,7 +73,7 @@ test('When using routes `decompress` settings :', async (t) => {
     t.equal(usedCustomGlobal, false)
 
     t.equal(response.statusCode, 200)
-    t.equal(response.body, 'fastify-compress')
+    t.equal(response.body, '@fastify/compress')
   })
 
   t.test('it should decompress data using the route custom provided `createGunzip` method', async (t) => {
@@ -112,7 +112,7 @@ test('When using routes `decompress` settings :', async (t) => {
       t.equal(usedCustomGlobal, true)
 
       t.equal(response.statusCode, 200)
-      t.equal(response.body, 'fastify-compress')
+      t.equal(response.body, '@fastify/compress')
 
       usedCustom = false
       usedCustomGlobal = false
@@ -131,7 +131,7 @@ test('When using routes `decompress` settings :', async (t) => {
     t.equal(usedCustomGlobal, false)
 
     t.equal(response.statusCode, 200)
-    t.equal(response.body, 'fastify-compress')
+    t.equal(response.body, '@fastify/compress')
   })
 
   t.test('it should not decompress data when route `decompress` option is set to `false`', async (t) => {
@@ -163,7 +163,7 @@ test('When using routes `decompress` settings :', async (t) => {
       t.equal(usedCustomGlobal, true)
 
       t.equal(response.statusCode, 200)
-      t.equal(response.body, 'fastify-compress')
+      t.equal(response.body, '@fastify/compress')
 
       usedCustomGlobal = false
     })
@@ -251,7 +251,7 @@ test('When using the old routes `{ config: decompress }` option :', async (t) =>
       t.equal(usedCustomGlobal, true)
 
       t.equal(response.statusCode, 200)
-      t.equal(response.body, 'fastify-compress')
+      t.equal(response.body, '@fastify/compress')
 
       usedCustom = false
       usedCustomGlobal = false
@@ -270,7 +270,7 @@ test('When using the old routes `{ config: decompress }` option :', async (t) =>
     t.equal(usedCustomGlobal, false)
 
     t.equal(response.statusCode, 200)
-    t.equal(response.body, 'fastify-compress')
+    t.equal(response.body, '@fastify/compress')
   })
 
   t.test('it should use the old routes `{ config: decompress }` options over routes `decompress` options', async (t) => {


### PR DESCRIPTION
This pull request renames the module according to the discussion in
https://github.com/fastify/fastify/issues/3733.

Note that the deprecation module has _already been published_ and that the
code for it does not exist in this repository. The code for the published
deprecation module was generated by https://github.com/fastify/deprecate-modules
and run on @jsumners local system.

Coordinating the drastic changes to the code for the module deprecation and
then restoring the code for the module renaming would have been extremely
difficult and prohibitively tedious.

**Important:** no further releases should be added to the old major version.
