### PR TITLE
Update to Fastify v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,9 @@ jobs:
     strategy:
       matrix:
         node-version:
-          - 10
-          - 12
           - 14
           - 16
-          - 17
+          - 18
         os:
           - macos-latest
           - ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ The plugin automatically decides if a payload should be compressed based on its 
 ### Global hook
 The global compression hook is enabled by default. To disable it, pass the option `{ global: false }`:
 ```javascript
-fastify.register(
-  require('@fastify/compress'),
+await fastify.register(
+  import('@fastify/compress'),
   { global: false }
 )
 ```
@@ -46,8 +46,8 @@ Important note! If you are using `@fastify/compress` plugin together with `@fast
 ### Per Route options
 You can specify different options for compression per route by passing in the `compress` options on the route's configuration.
 ```javascript
-fastify.register(
-  require('@fastify/compress'),
+await fastify.register(
+  import('@fastify/compress'),
   { global: false }
 )
 
@@ -74,21 +74,19 @@ Note that the compress method is configured with either the per route parameters
 the plugin was defined as global.
 
 ```javascript
-const fs = require('fs')
-const fastify = require('fastify')()
+import fs from 'fs'
+import fastify from 'fastify'
 
-fastify.register(require('@fastify/compress'), { global: false })
+const app = fastify()
+await app.register(import('@fastify/compress'), { global: false })
 
-fastify.get('/', (req, reply) => {
+app.get('/', (req, reply) => {
   reply
     .type('text/plain')
     .compress(fs.createReadStream('./package.json'))
 })
 
-fastify.listen(3000, function (err) {
-  if (err) throw err
-  console.log(`server listening on ${fastify.server.address().port}`)
-})
+await app.listen(3000)
 ```
 
 ## Compress Options
@@ -96,16 +94,16 @@ fastify.listen(3000, function (err) {
 ### threshold
 The minimum byte size for a response to be compressed. Defaults to `1024`.
 ```javascript
-fastify.register(
-  require('@fastify/compress'),
+await fastify.register(
+  import('@fastify/compress'),
   { threshold: 2048 }
 )
 ```
 ### customTypes
 [mime-db](https://github.com/jshttp/mime-db) is used to determine if a `content-type` should be compressed. You can compress additional content types via regular expression.
 ```javascript
-fastify.register(
-  require('@fastify/compress'),
+await fastify.register(
+  import('@fastify/compress'),
   { customTypes: /x-protobuf$/ }
 )
 ```
@@ -113,8 +111,8 @@ fastify.register(
 ### onUnsupportedEncoding
 When the encoding is not supported, a custom error response can be sent in place of the uncompressed payload by setting the `onUnsupportedEncoding(encoding, request, reply)` option to be a function that can modify the reply and return a `string | Buffer | Stream | Error` payload.
 ```javascript
-fastify.register(
-  require('@fastify/compress'),
+await fastify.register(
+  import('@fastify/compress'),
   {
     onUnsupportedEncoding: (encoding, request, reply) => {
       reply.code(406)
@@ -130,8 +128,8 @@ You can selectively disable response compression by using the `x-no-compression`
 ### Inflate pre-compressed bodies for clients that do not support compression
 Optional feature to inflate pre-compressed data if the client does not include one of the supported compression types in its `accept-encoding` header.
 ```javascript
-fastify.register(
-  require('@fastify/compress'),
+await fastify.register(
+  import('@fastify/compress'),
   { inflateIfDeflated: true }
 )
 
@@ -146,8 +144,8 @@ fastify.get('/file', (req, reply) =>
 By default, `@fastify/compress` prioritizes compression as described [at the beginning of §Usage - Compress replies](#usage). You can change that by passing an array of compression tokens to the `encodings` option:
 
 ```javascript
-fastify.register(
-  require('@fastify/compress'),
+await fastify.register(
+  import('@fastify/compress'),
   // Only support gzip and deflate, and prefer deflate to gzip
   { encodings: ['deflate', 'gzip'] }
 )
@@ -176,7 +174,7 @@ By default, `@fastify/compress` removes the reply `Content-Length` header. You c
 
 ```javascript
   // Global plugin scope
-  server.register(fastifyCompress, { global: true, removeContentLengthHeader: false });
+  await server.register(fastifyCompress, { global: true, removeContentLengthHeader: false });
 
   // Route specific scope
   fastify.get('/file', {
@@ -204,8 +202,8 @@ If the request header is missing, the plugin will not do anything and yield to t
 
 The global request decompression hook is enabled by default. To disable it, pass the option `{ global: false }`:
 ```javascript
-fastify.register(
-  require('@fastify/compress'),
+await fastify.register(
+  import('@fastify/compress'),
   { global: false }
 )
 ```
@@ -216,8 +214,8 @@ Remember that thanks to the Fastify encapsulation model, you can set a global de
 
 You can specify different options for decompression per route by passing in the `decompress` options on the route's configuration.
 ```javascript
-fastify.register(
-  require('@fastify/compress'),
+await fastify.register(
+  import('@fastify/compress'),
   { global: false }
 )
 
@@ -241,8 +239,8 @@ fastify.get('/custom-route', {
 By default, `@fastify/compress` accepts all encodings specified [at the beginning of §Usage - Decompress request payloads](#usage). You can change that by passing an array of compression tokens to the `requestEncodings` option:
 
 ```javascript
-fastify.register(
-  require('@fastify/compress'),
+await fastify.register(
+  import('@fastify/compress'),
   // Only support gzip
   { requestEncodings: ['gzip'] }
 )
@@ -261,8 +259,8 @@ Note that if the request payload is not compressed, `@fastify/compress` will try
 When the request payload encoding is not supported, you can customize the response error by setting the `onUnsupportedEncoding(request, encoding)` option to be a function that returns an error.
 
 ```javascript
-fastify.register(
-  require('@fastify/compress'),
+await fastify.register(
+  import('@fastify/compress'),
   {
      onUnsupportedRequestEncoding: (request, encoding) => {
       return {
@@ -281,8 +279,8 @@ fastify.register(
 When the request payload cannot be decompressed using the detected algorithm, you can customize the response error setting the `onInvalidRequestPayload(request, encoding)` option to be a function that returns an error.
 
 ```javascript
-fastify.register(
-  require('@fastify/compress'),
+await fastify.register(
+  import('@fastify/compress'),
   {
     onInvalidRequestPayload: (request, encoding, error) => {
       return {

--- a/index.js
+++ b/index.js
@@ -552,5 +552,5 @@ function createError (code, message, statusCode) {
 
 module.exports = fp(compressPlugin, {
   fastify: '4.x',
-  name: 'fastify-compress'
+  name: '@fastify/compress'
 })

--- a/index.js
+++ b/index.js
@@ -143,8 +143,8 @@ function processCompressParams (opts) {
 
   params.encodings = Array.isArray(opts.encodings)
     ? supportedEncodings
-        .filter(encoding => opts.encodings.includes(encoding))
-        .sort((a, b) => opts.encodings.indexOf(a) - supportedEncodings.indexOf(b))
+      .filter(encoding => opts.encodings.includes(encoding))
+      .sort((a, b) => opts.encodings.indexOf(a) - supportedEncodings.indexOf(b))
     : supportedEncodings
 
   return params
@@ -175,8 +175,8 @@ function processDecompressParams (opts) {
 
   params.encodings = Array.isArray(opts.requestEncodings)
     ? supportedEncodings
-        .filter(encoding => opts.requestEncodings.includes(encoding))
-        .sort((a, b) => opts.requestEncodings.indexOf(a) - supportedEncodings.indexOf(b))
+      .filter(encoding => opts.requestEncodings.includes(encoding))
+      .sort((a, b) => opts.requestEncodings.indexOf(a) - supportedEncodings.indexOf(b))
     : supportedEncodings
 
   if (opts.forceRequestEncoding) {
@@ -268,8 +268,8 @@ function buildRouteCompress (fastify, params, routeOptions, decorateOnly) {
 
     params.removeContentLengthHeader
       ? reply
-          .header('Content-Encoding', encoding)
-          .removeHeader('content-length')
+        .header('Content-Encoding', encoding)
+        .removeHeader('content-length')
       : reply.header('Content-Encoding', encoding)
 
     stream = zipStream(params.compressStream, encoding)
@@ -393,8 +393,8 @@ function compress (params) {
 
     params.removeContentLengthHeader
       ? this
-          .header('Content-Encoding', encoding)
-          .removeHeader('content-length')
+        .header('Content-Encoding', encoding)
+        .removeHeader('content-length')
       : this.header('Content-Encoding', encoding)
 
     stream = zipStream(params.compressStream, encoding)
@@ -551,6 +551,6 @@ function createError (code, message, statusCode) {
 }
 
 module.exports = fp(compressPlugin, {
-  fastify: '3.x',
+  fastify: '4.x',
   name: 'fastify-compress'
 })

--- a/package.json
+++ b/package.json
@@ -23,10 +23,10 @@
     "@typescript-eslint/eslint-plugin": "^5.9.0",
     "@typescript-eslint/parser": "^5.9.0",
     "adm-zip": "^0.5.9",
-    "fastify": "^3.25.3",
+    "fastify": "^4.0.0-rc.2",
     "jsonstream": "^1.0.3",
     "pre-commit": "^1.2.2",
-    "standard": "^16.0.4",
+    "standard": "^17.0.0",
     "tap": "^16.0.0",
     "tsd": "^0.20.0",
     "typescript": "^4.5.4"

--- a/test/routes-compress.test.js
+++ b/test/routes-compress.test.js
@@ -225,27 +225,20 @@ test('When using routes `compress` settings :', async (t) => {
   })
 
   t.test('it should throw an error on invalid route `compress` settings', async (t) => {
-    t.plan(2)
+    t.plan(1)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: false })
 
-    fastify.get('/', {
-      compress: 'bad config'
-    }, (request, reply) => {
-      reply.send('')
-    })
-
-    await fastify.inject({
-      url: '/',
-      method: 'GET',
-      headers: {
-        'accept-encoding': 'gzip'
-      }
-    }).catch((err) => {
-      t.type(err, Error)
+    try {
+      fastify.get('/', {
+        compress: 'bad config'
+      }, (request, reply) => {
+        reply.send('')
+      })
+    } catch (err) {
       t.equal(err.message, 'Unknown value for route compress configuration')
-    })
+    }
   })
 })
 
@@ -385,32 +378,25 @@ test('When using the old routes `{ config: compress }` option :', async (t) => {
   })
 
   t.test('it should use the old routes `{ config: compress }` options over routes `compress` options', async (t) => {
-    t.plan(2)
+    t.plan(1)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: false })
 
-    fastify.get('/', {
-      compress: {
-        zlib: { createGzip: () => zlib.createGzip() }
-      },
-      config: {
-        compress: 'bad config'
-      }
-    }, (request, reply) => {
-      reply.send('')
-    })
-
-    await fastify.inject({
-      url: '/',
-      method: 'GET',
-      headers: {
-        'accept-encoding': 'gzip'
-      }
-    }).catch((err) => {
-      t.type(err, Error)
+    try {
+      fastify.get('/', {
+        compress: {
+          zlib: { createGzip: () => zlib.createGzip() }
+        },
+        config: {
+          compress: 'bad config'
+        }
+      }, (request, reply) => {
+        reply.send('')
+      })
+    } catch (err) {
       t.equal(err.message, 'Unknown value for route compress configuration')
-    })
+    }
   })
 })
 

--- a/test/routes-decompress.test.js
+++ b/test/routes-decompress.test.js
@@ -189,26 +189,18 @@ test('When using routes `decompress` settings :', async (t) => {
   })
 
   t.test('it should throw an error on invalid route `decompress` settings', async (t) => {
-    t.plan(2)
+    t.plan(1)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: false })
 
-    fastify.post('/', { decompress: 'bad config' }, (request, reply) => {
-      reply.send(request.body.name)
-    })
-
-    await fastify.inject({
-      url: '/',
-      method: 'POST',
-      headers: {
-        'content-encoding': 'gzip'
-      },
-      payload: ''
-    }).catch((err) => {
-      t.type(err, Error)
+    try {
+      fastify.post('/', { decompress: 'bad config' }, (request, reply) => {
+        reply.send(request.body.name)
+      })
+    } catch (err) {
       t.equal(err.message, 'Unknown value for route decompress configuration')
-    })
+    }
   })
 })
 
@@ -274,32 +266,24 @@ test('When using the old routes `{ config: decompress }` option :', async (t) =>
   })
 
   t.test('it should use the old routes `{ config: decompress }` options over routes `decompress` options', async (t) => {
-    t.plan(2)
+    t.plan(1)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: false })
 
-    fastify.post('/', {
-      decompress: {
-        zlib: { createGunzip: () => zlib.createGunzip() }
-      },
-      config: {
-        decompress: 'bad config'
-      }
-    }, (request, reply) => {
-      reply.send(request.body.name)
-    })
-
-    await fastify.inject({
-      url: '/',
-      method: 'POST',
-      headers: {
-        'content-encoding': 'gzip'
-      },
-      payload: ''
-    }).catch((err) => {
-      t.type(err, Error)
+    try {
+      fastify.post('/', {
+        decompress: {
+          zlib: { createGunzip: () => zlib.createGunzip() }
+        },
+        config: {
+          decompress: 'bad config'
+        }
+      }, (request, reply) => {
+        reply.send(request.body.name)
+      })
+    } catch (err) {
       t.equal(err.message, 'Unknown value for route decompress configuration')
-    })
+    }
   })
 })


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Due to the changes introduced in https://github.com/fastify/fastify/pull/2954, we need to change how this plugin is registered from:

```js
  const fastify = Fastify()
  fastify.register(compressPlugin, {
    global: true
  })
  fastify.get('/one', (request, reply) => {
    reply.send(json)
  })
```

to

```js
  const fastify = Fastify()
  await fastify.register(compressPlugin, {
    global: true
  }) // we must use await or after now.
  fastify.get('/one', (request, reply) => {
    reply.send(json)
  })
```

The fundamental problem of the change is that in Fastify v4 routes are now defined synchronously while plugins are defined asynchronously. Therefore requiring the await as there is no library to look for the `onRoute` hook. 

Note that users of nested plugins are not impacted, so the following will still work:

```js
  const fastify = Fastify()
  fastify.register(compressPlugin, {
    global: true
  })
  fastify.register(async (fastify) => {
    fastify.get('/one', (request, reply) => {
      reply.send(json)
    })
  })
```

Are we ok with the change?

cc @metcoder95 @fastify/core @fastify/plugins

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
