### PR TITLE
docs: fix default zlib level

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,7 +163,7 @@ You can tune compression by setting the `brotliOptions` and `zlibOptions` proper
       },
     },
     zlibOptions: {
-      level: 9, // default is 9, max is 9, min is 0
+      level: 6, // default is typically 6, max is 9, min is 0
     }
   });
 ```


### PR DESCRIPTION
This isn't well-covered in the [Node docs](https://nodejs.org/api/zlib.html#zlib_class_options), but zlib's `level` actually defaults to `zlib.constants.Z_DEFAULT_COMPRESSION` (`-1`), which zlib resolves to 6, not 9:

> `Z_DEFAULT_COMPRESSION` requests a default compromise between speed and compression (currently equivalent to level 6).
(https://www.zlib.net/manual.html#Basic)

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
