### PR TITLE
Fix default supported content types

### DIFF
--- a/index.js
+++ b/index.js
@@ -107,6 +107,8 @@ function fastifyCompress (fastify, opts, next) {
   next()
 }
 
+const defaultCompressibleTypes = /^text\/(?!event-stream)|(\+|\/)json(;|$)|(\+|\/)text(;|$)|(\+|\/)xml(;|$)|octet-stream(;|$)/
+
 function processCompressParams (opts) {
   /* istanbul ignore next */
   if (!opts) {
@@ -123,7 +125,7 @@ function processCompressParams (opts) {
   params.onUnsupportedEncoding = opts.onUnsupportedEncoding
   params.inflateIfDeflated = opts.inflateIfDeflated === true
   params.threshold = typeof opts.threshold === 'number' ? opts.threshold : 1024
-  params.compressibleTypes = opts.customTypes instanceof RegExp ? opts.customTypes : /^text\/(?!event-stream)|(\+|\/)json(;|$)|(\+|\/)text(;|$)|(\+|\/)xml(;|$)|octet-stream(;|$)/
+  params.compressibleTypes = opts.customTypes instanceof RegExp ? opts.customTypes : defaultCompressibleTypes
   params.compressStream = {
     br: () => ((opts.zlib || zlib).createBrotliCompress || zlib.createBrotliCompress)(params.brotliOptions),
     gzip: () => ((opts.zlib || zlib).createGzip || zlib.createGzip)(params.zlibOptions),

--- a/index.js
+++ b/index.js
@@ -123,7 +123,7 @@ function processCompressParams (opts) {
   params.onUnsupportedEncoding = opts.onUnsupportedEncoding
   params.inflateIfDeflated = opts.inflateIfDeflated === true
   params.threshold = typeof opts.threshold === 'number' ? opts.threshold : 1024
-  params.compressibleTypes = opts.customTypes instanceof RegExp ? opts.customTypes : /^text\/(?!event-stream)|\+json$|\+text$|\+xml$|octet-stream$/
+  params.compressibleTypes = opts.customTypes instanceof RegExp ? opts.customTypes : /^text\/(?!event-stream)|(\+|\/)json(;|$)|(\+|\/)text(;|$)|(\+|\/)xml(;|$)|octet-stream(;|$)/
   params.compressStream = {
     br: () => ((opts.zlib || zlib).createBrotliCompress || zlib.createBrotliCompress)(params.brotliOptions),
     gzip: () => ((opts.zlib || zlib).createGzip || zlib.createGzip)(params.zlibOptions),

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -3069,7 +3069,7 @@ for (const contentType of defaultSupportedContentTypes) {
 
     fastify.get('/', (request, reply) => {
       reply
-        .type('text/xml; charset=utf-8')
+        .type(contentType)
         .send(createReadStream('./package.json'))
     })
 
@@ -3093,14 +3093,14 @@ const notByDefaultSupportedContentTypes = [
 ]
 
 for (const contentType of notByDefaultSupportedContentTypes) {
-  test(`It should compress data if content-type is supported by default, ${contentType}`, async (t) => {
+  test(`It should not compress data if content-type is not supported by default, ${contentType}`, async (t) => {
     t.plan(2)
     const fastify = Fastify()
     await fastify.register(compressPlugin)
 
     fastify.get('/', (request, reply) => {
       reply
-        .type('text/xml; charset=utf-8')
+        .type(contentType)
         .send(createReadStream('./package.json'))
     })
 
@@ -3112,8 +3112,7 @@ for (const contentType of notByDefaultSupportedContentTypes) {
       }
     })
     const file = readFileSync('./package.json', 'utf8')
-    const payload = zlib.gunzipSync(response.rawPayload)
-    t.equal(response.headers['content-encoding'], 'gzip')
-    t.equal(payload.toString('utf-8'), file)
+    t.notOk(response.headers['content-encoding'])
+    t.equal(response.rawPayload.toString('utf-8'), file)
   })
 }

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -3048,3 +3048,72 @@ test('It should return an error when using `reply.compress()` with a missing pay
     statusCode: 500
   }, payload)
 })
+
+const defaultSupportedContentTypes = [
+  'application/json',
+  'application/json; charset=utf-8',
+  'application/graphql-response+json',
+  'application/graphql-response+json; charset=utf-8',
+  'application/xml',
+  'application/xml; charset=utf-8',
+  'octet-stream',
+  'text/xml',
+  'text/xml; charset=utf-8'
+]
+
+for (const contentType of defaultSupportedContentTypes) {
+  test(`It should compress data if content-type is supported by default, ${contentType}`, async (t) => {
+    t.plan(2)
+    const fastify = Fastify()
+    await fastify.register(compressPlugin)
+
+    fastify.get('/', (request, reply) => {
+      reply
+        .type('text/xml; charset=utf-8')
+        .send(createReadStream('./package.json'))
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: {
+        'accept-encoding': 'gzip'
+      }
+    })
+    const file = readFileSync('./package.json', 'utf8')
+    const payload = zlib.gunzipSync(response.rawPayload)
+    t.equal(response.headers['content-encoding'], 'gzip')
+    t.equal(payload.toString('utf-8'), file)
+  })
+}
+
+const notByDefaultSupportedContentTypes = [
+  'application/fastify',
+  'text/event-stream'
+]
+
+for (const contentType of notByDefaultSupportedContentTypes) {
+  test(`It should compress data if content-type is supported by default, ${contentType}`, async (t) => {
+    t.plan(2)
+    const fastify = Fastify()
+    await fastify.register(compressPlugin)
+
+    fastify.get('/', (request, reply) => {
+      reply
+        .type('text/xml; charset=utf-8')
+        .send(createReadStream('./package.json'))
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: {
+        'accept-encoding': 'gzip'
+      }
+    })
+    const file = readFileSync('./package.json', 'utf8')
+    const payload = zlib.gunzipSync(response.rawPayload)
+    t.equal(response.headers['content-encoding'], 'gzip')
+    t.equal(payload.toString('utf-8'), file)
+  })
+}


### PR DESCRIPTION
Hey there, quick fix to fix support for [content-type syntax](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Type#syntax).

I encountered this issue after using an endpoint that was specifying encoding and compression wasn't being applied.

## Before
<img width="737" alt="Screenshot 2023-03-24 at 17 20 10" src="https://user-images.githubusercontent.com/10779424/227596863-3c602799-156d-45be-a990-837dcb741d15.png">

## After
<img width="744" alt="Screenshot 2023-03-24 at 17 19 53" src="https://user-images.githubusercontent.com/10779424/227596897-9f7adf8b-79fa-4a79-8184-e65754d63c2c.png">

