### PR TITLE
perf(index): convert unused capture groups to non-capture groups

### DIFF
--- a/index.js
+++ b/index.js
@@ -108,7 +108,7 @@ function fastifyCompress (fastify, opts, next) {
   next()
 }
 
-const defaultCompressibleTypes = /^text\/(?!event-stream)|(\+|\/)json(;|$)|(\+|\/)text(;|$)|(\+|\/)xml(;|$)|octet-stream(;|$)/
+const defaultCompressibleTypes = /^text\/(?!event-stream)|(?:\+|\/)json(?:;|$)|(?:\+|\/)text(?:;|$)|(?:\+|\/)xml(?:;|$)|octet-stream(?:;|$)/
 
 function processCompressParams (opts) {
   /* istanbul ignore next */
@@ -460,7 +460,7 @@ function getEncodingHeader (encodings, request) {
       // consider the no-preference token as gzip for downstream compat
       // and x-gzip as an alias of gzip
       // ref.: [HTTP/1.1 RFC 7230 section 4.2.3](https://datatracker.ietf.org/doc/html/rfc7230#section-4.2.3)
-      .replace(/\*|x-gzip/g, 'gzip')
+      .replace(/\*|x-gzip/gu, 'gzip')
     return encodingNegotiator.negotiate(header, encodings)
   } else {
     return undefined

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -766,7 +766,7 @@ test('It should not compress :', async (t) => {
       t.plan(2)
 
       const fastify = Fastify()
-      await fastify.register(compressPlugin, { customTypes: /x-user-header$/ })
+      await fastify.register(compressPlugin, { customTypes: /x-user-header$/u })
 
       fastify.get('/', (request, reply) => {
         reply
@@ -1101,7 +1101,7 @@ test('It should not compress :', async (t) => {
       t.plan(2)
 
       const fastify = Fastify()
-      await fastify.register(compressPlugin, { customTypes: /x-user-header$/ })
+      await fastify.register(compressPlugin, { customTypes: /x-user-header$/u })
 
       fastify.get('/', (request, reply) => {
         reply
@@ -2445,7 +2445,7 @@ test('`Accept-Encoding` request header values :', async (t) => {
 test('It should compress data if `customTypes` is set and matches `Content-Type` reply header value', async (t) => {
   t.plan(2)
   const fastify = Fastify()
-  await fastify.register(compressPlugin, { customTypes: /x-user-header$/ })
+  await fastify.register(compressPlugin, { customTypes: /x-user-header$/u })
 
   fastify.get('/', (request, reply) => {
     reply


### PR DESCRIPTION
See https://github.com/fastify/fastify-autoload/pull/330

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
