### PR TITLE
perf!: reduce default brotli compression factor to 4, was before 11 (maximum)

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ You can tune compression by setting the `brotliOptions` and `zlibOptions` proper
     brotliOptions: {
       params: {
         [zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT, // useful for APIs that primarily return text
-        [zlib.constants.BROTLI_PARAM_QUALITY]: 4, // default is 11, max is 11, min is 0
+        [zlib.constants.BROTLI_PARAM_QUALITY]: 4, // default is 4, max is 11, min is 0
       },
     },
     zlibOptions: {

--- a/index.js
+++ b/index.js
@@ -117,7 +117,12 @@ function processCompressParams (opts) {
   }
 
   const params = {
-    global: (typeof opts.global === 'boolean') ? opts.global : true
+    global: (typeof opts.global === 'boolean') ? opts.global : true,
+    /**
+     * Default of 4 as 11 has a heavy impact on performance.
+     * @see {@link https://blog.cloudflare.com/this-is-brotli-from-origin#testing}
+     */
+    brotliOptions: { [zlib.constants.BROTLI_PARAM_QUALITY]: 4, ...opts.brotliOptions }
   }
 
   params.removeContentLengthHeader = typeof opts.removeContentLengthHeader === 'boolean' ? opts.removeContentLengthHeader : true


### PR DESCRIPTION
BREAKING CHANGE: The default brotli quality value currently is 11, which is not meant to be used in an on the fly compression context. Change this to a more reasonable default value of 4.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [ ] run `npm run test` and `npm run benchmark`
- [ ] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
