### PR TITLE
fix: default brotliOptions does not applied to createBrotliCompress and createBrotliDecompress

### DIFF
--- a/index.js
+++ b/index.js
@@ -109,6 +109,13 @@ function fastifyCompress (fastify, opts, next) {
 }
 
 const defaultCompressibleTypes = /^text\/(?!event-stream)|(?:\+|\/)json(?:;|$)|(?:\+|\/)text(?:;|$)|(?:\+|\/)xml(?:;|$)|octet-stream(?:;|$)/u
+const recommendedDefaultBrotliOptions = {
+  params: {
+    // Default of 4 as 11 has a heavy impact on performance.
+    // https://blog.cloudflare.com/this-is-brotli-from-origin#testing
+    [zlib.constants.BROTLI_PARAM_QUALITY]: 4
+  }
+}
 
 function processCompressParams (opts) {
   /* istanbul ignore next */
@@ -122,14 +129,7 @@ function processCompressParams (opts) {
 
   params.removeContentLengthHeader = typeof opts.removeContentLengthHeader === 'boolean' ? opts.removeContentLengthHeader : true
   params.brotliOptions = params.global
-    ? {
-        params: {
-          // Default of 4 as 11 has a heavy impact on performance.
-          // https://blog.cloudflare.com/this-is-brotli-from-origin#testing
-          [zlib.constants.BROTLI_PARAM_QUALITY]: 4
-        },
-        ...opts.brotliOptions
-      }
+    ? { ...recommendedDefaultBrotliOptions, ...opts.brotliOptions }
     : opts.brotliOptions
   params.zlibOptions = opts.zlibOptions
   params.onUnsupportedEncoding = opts.onUnsupportedEncoding

--- a/index.js
+++ b/index.js
@@ -117,16 +117,16 @@ function processCompressParams (opts) {
   }
 
   const params = {
-    global: (typeof opts.global === 'boolean') ? opts.global : true,
-    /**
-     * Default of 4 as 11 has a heavy impact on performance.
-     * @see {@link https://blog.cloudflare.com/this-is-brotli-from-origin#testing}
-     */
-    brotliOptions: { [zlib.constants.BROTLI_PARAM_QUALITY]: 4, ...opts.brotliOptions }
+    global: (typeof opts.global === 'boolean') ? opts.global : true
   }
 
   params.removeContentLengthHeader = typeof opts.removeContentLengthHeader === 'boolean' ? opts.removeContentLengthHeader : true
-  params.brotliOptions = opts.brotliOptions
+  params.brotliOptions = {
+    // Default of 4 as 11 has a heavy impact on performance.
+    // https://blog.cloudflare.com/this-is-brotli-from-origin#testing
+    params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 4 },
+    ...opts.brotliOptions
+  }
   params.zlibOptions = opts.zlibOptions
   params.onUnsupportedEncoding = opts.onUnsupportedEncoding
   params.inflateIfDeflated = opts.inflateIfDeflated === true

--- a/index.js
+++ b/index.js
@@ -121,12 +121,16 @@ function processCompressParams (opts) {
   }
 
   params.removeContentLengthHeader = typeof opts.removeContentLengthHeader === 'boolean' ? opts.removeContentLengthHeader : true
-  params.brotliOptions = {
-    // Default of 4 as 11 has a heavy impact on performance.
-    // https://blog.cloudflare.com/this-is-brotli-from-origin#testing
-    params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 4 },
-    ...opts.brotliOptions
-  }
+  params.brotliOptions = params.global
+    ? {
+        params: {
+          // Default of 4 as 11 has a heavy impact on performance.
+          // https://blog.cloudflare.com/this-is-brotli-from-origin#testing
+          [zlib.constants.BROTLI_PARAM_QUALITY]: 4
+        },
+        ...opts.brotliOptions
+      }
+    : opts.brotliOptions
   params.zlibOptions = opts.zlibOptions
   params.onUnsupportedEncoding = opts.onUnsupportedEncoding
   params.inflateIfDeflated = opts.inflateIfDeflated === true

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -2566,8 +2566,8 @@ test('It should send data compressed according to `brotliOptions` :', async (t) 
     t.equal(response.headers['content-encoding'], 'br')
     t.equal(payload.toString('utf-8'), file)
 
-    const compressedBufferPayload = zlib.brotliCompressSync(file, brotliOptions)
-    t.same(response.rawPayload, compressedBufferPayload)
+    const compressedPayload = zlib.brotliCompressSync(file, brotliOptions)
+    t.same(response.rawPayload, compressedPayload)
   })
 
   t.test('default BROTLI_PARAM_QUALITY to be 4', async (t) => {
@@ -2594,8 +2594,8 @@ test('It should send data compressed according to `brotliOptions` :', async (t) 
     const defaultBrotliOptions = {
       params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 4 }
     }
-    const compressedBufferPayload = zlib.brotliCompressSync(file, defaultBrotliOptions)
-    t.same(response.rawPayload, compressedBufferPayload)
+    const compressedPayload = zlib.brotliCompressSync(file, defaultBrotliOptions)
+    t.same(response.rawPayload, compressedPayload)
   })
 })
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -107,7 +107,7 @@ appWithoutGlobal.inject(
     }
   },
   (err) => {
-    expectType<Error>(err)
+    expectType<Error | undefined>(err)
   }
 )
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -40,7 +40,7 @@ app.get('/test-two', async (request, reply) => {
   expectError(reply.compress())
 })
 
-// Instanciation of an app without global
+// Instantiation of an app without global
 const appWithoutGlobal: FastifyInstance = fastify()
 appWithoutGlobal.register(fastifyCompress, { global: false })
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -111,7 +111,7 @@ appWithoutGlobal.inject(
   }
 )
 
-// Instanciation of an app that should trigger a typescript error
+// Instantiation of an app that should trigger a typescript error
 const appThatTriggerAnError = fastify()
 expectError(appThatTriggerAnError.register(fastifyCompress, {
   global: true,


### PR DESCRIPTION
## The problem
I encounted a remarkable performance slow down after migrating from Koa. 
Although the doc mentions [fastify/compress](https://github.com/fastify/fastify-compress/blob/master/README.md?plain=1#L172) already sets the compression level to 4, but it takes too long to compress (3MB for 5 sec) a json. I guess it is configured unexpectedly by default. 

After some investigation, it could be related to the previous merge request #278. 
Unless I explicitly set the compression level to `4`, I will get `11` (BROTLI_DEFAULT_QUALITY). 

## The root cause
The compression level is a member of `brotliOptions.params` not `brotliOptions`. https://nodejs.org/api/zlib.html#class-brotlioptions

And unfortunately the global default option is overwritten by custom option afterwards https://github.com/fastify/fastify-compress/blob/master/index.js#L129

## The change
1. Proposed a fix with additional test cases included. 
2. Added a new test case to ensure with default options, response will be compressed with level `4`. 
3. Changed the existing test case to speicfy the compression level to `8` and check if it is compressed expectedly.

Loop in author of previous commit @kahlstrm as well.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
