### PR TITLE
Fix/incorrect vary header

### DIFF
--- a/index.js
+++ b/index.js
@@ -242,7 +242,6 @@ function buildRouteCompress (fastify, params, routeOptions, decorateOnly) {
       // response is already compressed
       return next()
     }
-    setVaryHeader(reply)
 
     let stream, encoding
     const noCompress =
@@ -280,6 +279,7 @@ function buildRouteCompress (fastify, params, routeOptions, decorateOnly) {
       payload = intoStream(payload)
     }
 
+    setVaryHeader(reply)
     params.removeContentLengthHeader
       ? reply
         .header('Content-Encoding', encoding)
@@ -360,7 +360,6 @@ function compress (params) {
       return
     }
 
-    setVaryHeader(this)
     let stream, encoding
     const noCompress =
       // don't compress on x-no-compression header
@@ -405,6 +404,7 @@ function compress (params) {
       payload = intoStream(payload)
     }
 
+    setVaryHeader(this)
     params.removeContentLengthHeader
       ? this
         .header('Content-Encoding', encoding)
@@ -419,9 +419,10 @@ function compress (params) {
 
 function setVaryHeader (reply) {
   if (reply.hasHeader('Vary')) {
-    const varyHeader = Array.isArray(reply.getHeader('Vary')) ? reply.getHeader('Vary') : [reply.getHeader('Vary')]
-    if (!varyHeader.some((h) => h.includes('accept-encoding'))) {
-      reply.header('Vary', `${varyHeader.join(', ')}, accept-encoding`)
+    const rawHeaderValue = reply.getHeader('Vary')
+    const headerValueArray = Array.isArray(rawHeaderValue) ? rawHeaderValue : [rawHeaderValue]
+    if (!headerValueArray.some((h) => h.includes('accept-encoding'))) {
+      reply.header('Vary', headerValueArray.concat('accept-encoding').join(', '))
     }
   } else {
     reply.header('Vary', 'accept-encoding')

--- a/index.js
+++ b/index.js
@@ -280,11 +280,10 @@ function buildRouteCompress (fastify, params, routeOptions, decorateOnly) {
     }
 
     setVaryHeader(reply)
-    params.removeContentLengthHeader
-      ? reply
-        .header('Content-Encoding', encoding)
-        .removeHeader('content-length')
-      : reply.header('Content-Encoding', encoding)
+    reply.header('Content-Encoding', encoding)
+    if (params.removeContentLengthHeader) {
+      reply.removeHeader('content-length')
+    }
 
     stream = zipStream(params.compressStream, encoding)
     pump(payload, stream, onEnd.bind(reply))
@@ -405,11 +404,10 @@ function compress (params) {
     }
 
     setVaryHeader(this)
-    params.removeContentLengthHeader
-      ? this
-        .header('Content-Encoding', encoding)
-        .removeHeader('content-length')
-      : this.header('Content-Encoding', encoding)
+    this.header('Content-Encoding', encoding)
+    if (params.removeContentLengthHeader) {
+      this.removeHeader('content-length')
+    }
 
     stream = zipStream(params.compressStream, encoding)
     pump(payload, stream, onEnd.bind(this))

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -263,14 +263,14 @@ test('It should send compressed Stream data when `global` is `true` :', async (t
     })
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.inflateSync(response.rawPayload)
-    t.equal(response.headers['content-encoding'], 'deflate')
     t.equal(response.headers.vary, 'accept-encoding')
+    t.equal(response.headers['content-encoding'], 'deflate')
     t.notOk(response.headers['content-length'], 'no content length')
     t.equal(payload.toString('utf-8'), file)
   })
 
   t.test('using gzip when `Accept-Encoding` request header is `gzip`', async (t) => {
-    t.plan(2)
+    t.plan(3)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true })
@@ -290,6 +290,7 @@ test('It should send compressed Stream data when `global` is `true` :', async (t
     })
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.gunzipSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'gzip')
     t.equal(payload.toString('utf-8'), file)
   })
@@ -433,7 +434,7 @@ test('It should send compressed JSON data when `global` is `true` :', async (t) 
 
 test('It should fallback to the default `gzip` encoding compression :', async (t) => {
   t.test('when `Accept-Encoding` request header value is set to `*`', async (t) => {
-    t.plan(2)
+    t.plan(3)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true })
@@ -453,12 +454,13 @@ test('It should fallback to the default `gzip` encoding compression :', async (t
     })
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.gunzipSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'gzip')
     t.equal(payload.toString('utf-8'), file)
   })
 
   t.test('when `Accept-Encoding` request header value is set to multiple `*` directives', async (t) => {
-    t.plan(2)
+    t.plan(3)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true })
@@ -478,6 +480,7 @@ test('It should fallback to the default `gzip` encoding compression :', async (t
     })
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.gunzipSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'gzip')
     t.equal(payload.toString('utf-8'), file)
   })
@@ -485,7 +488,7 @@ test('It should fallback to the default `gzip` encoding compression :', async (t
 
 test('When a custom `zlib` option is provided, it should compress data :`', async (t) => {
   t.test('using the custom `createBrotliCompress()` method', async (t) => {
-    t.plan(4)
+    t.plan(5)
 
     let usedCustom = false
     const customZlib = { createBrotliCompress: () => (usedCustom = true) && zlib.createBrotliCompress() }
@@ -510,13 +513,14 @@ test('When a custom `zlib` option is provided, it should compress data :`', asyn
 
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.brotliDecompressSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'br')
     t.notOk(response.headers['content-length'], 'no content length')
     t.equal(payload.toString('utf-8'), file)
   })
 
   t.test('using the custom `createDeflate()` method', async (t) => {
-    t.plan(4)
+    t.plan(5)
 
     let usedCustom = false
     const customZlib = { createDeflate: () => (usedCustom = true) && zlib.createDeflate() }
@@ -541,13 +545,14 @@ test('When a custom `zlib` option is provided, it should compress data :`', asyn
 
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.inflateSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'deflate')
     t.notOk(response.headers['content-length'], 'no content length')
     t.equal(payload.toString('utf-8'), file)
   })
 
   t.test('using the custom `createGzip()` method', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     let usedCustom = false
     const customZlib = { createGzip: () => (usedCustom = true) && zlib.createGzip() }
@@ -572,6 +577,7 @@ test('When a custom `zlib` option is provided, it should compress data :`', asyn
 
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.gunzipSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'gzip')
     t.equal(payload.toString('utf-8'), file)
   })
@@ -662,7 +668,7 @@ test('When a malformed custom `zlib` option is provided, it should compress data
 
 test('When `inflateIfDeflated` is `true` and `X-No-Compression` request header is `true` :', async (t) => {
   t.test('it should uncompress payloads using the deflate algorithm', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { threshold: 0, inflateIfDeflated: true })
@@ -680,12 +686,13 @@ test('When `inflateIfDeflated` is `true` and `X-No-Compression` request header i
       }
     })
     t.equal(response.statusCode, 200)
+    t.notOk(response.headers.vary)
     t.notOk(response.headers['content-encoding'])
     t.same(JSON.parse('' + response.payload), json)
   })
 
   t.test('it should uncompress payloads using the gzip algorithm', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { threshold: 0, inflateIfDeflated: true })
@@ -703,13 +710,14 @@ test('When `inflateIfDeflated` is `true` and `X-No-Compression` request header i
       }
     })
     t.equal(response.statusCode, 200)
+    t.notOk(response.headers.vary)
     t.notOk(response.headers['content-encoding'])
     t.same(JSON.parse('' + response.payload), json)
   })
 })
 
 test('it should not uncompress payloads using the zip algorithm', async (t) => {
-  t.plan(4)
+  t.plan(5)
 
   const fastify = Fastify()
   await fastify.register(compressPlugin, { threshold: 0, inflateIfDeflated: true })
@@ -731,6 +739,7 @@ test('it should not uncompress payloads using the zip algorithm', async (t) => {
     }
   })
   t.equal(response.statusCode, 200)
+  t.notOk(response.headers.vary)
   t.notOk(response.headers['content-encoding'])
   t.same(response.rawPayload, fileBuffer)
   t.equal(response.payload, fileBuffer.toString('utf-8'))
@@ -739,7 +748,7 @@ test('it should not uncompress payloads using the zip algorithm', async (t) => {
 test('It should not compress :', async (t) => {
   t.test('Using `reply.compress()` :', async (t) => {
     t.test('when payload length is smaller than the `threshold` defined value', async (t) => {
-      t.plan(3)
+      t.plan(4)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { threshold: 128 })
@@ -758,12 +767,13 @@ test('It should not compress :', async (t) => {
         }
       })
       t.equal(response.statusCode, 200)
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.equal(response.payload, 'a message')
     })
 
     t.test('when `customTypes` is set and does not match `Content-Type` reply header or `mime-db`', async (t) => {
-      t.plan(2)
+      t.plan(3)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { customTypes: /x-user-header$/u })
@@ -781,12 +791,13 @@ test('It should not compress :', async (t) => {
           'accept-encoding': 'gzip'
         }
       })
+      t.notOk(response.headers.vary, 'accept-encoding')
       t.notOk(response.headers['content-encoding'])
       t.equal(response.statusCode, 200)
     })
 
     t.test('when `customTypes` is a function and returns false on the provided `Content-Type` reply header`', async (t) => {
-      t.plan(2)
+      t.plan(3)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { customTypes: value => value === 'application/x-user-header' })
@@ -804,12 +815,13 @@ test('It should not compress :', async (t) => {
           'accept-encoding': 'gzip'
         }
       })
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.equal(response.statusCode, 200)
     })
 
     t.test('when `X-No-Compression` request header is `true`', async (t) => {
-      t.plan(3)
+      t.plan(4)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { global: true, threshold: 0 })
@@ -827,12 +839,13 @@ test('It should not compress :', async (t) => {
         }
       })
       t.equal(response.statusCode, 200)
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.same(JSON.parse(response.payload), json)
     })
 
     t.test('when `Content-Type` reply header is not set and the content is not detected as a compressible type', async (t) => {
-      t.plan(2)
+      t.plan(3)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { threshold: 0 })
@@ -855,12 +868,13 @@ test('It should not compress :', async (t) => {
           'accept-encoding': 'identity'
         }
       })
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.equal(response.payload, JSON.stringify(json))
     })
 
     t.test('when `Content-Type` reply header is a mime type with undefined compressible values', async (t) => {
-      t.plan(3)
+      t.plan(4)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { threshold: 0 })
@@ -879,12 +893,13 @@ test('It should not compress :', async (t) => {
         }
       })
       t.equal(response.statusCode, 200)
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.equal(response.payload, 'hello')
     })
 
     t.test('when `Content-Type` reply header value is `text/event-stream`', async (t) => {
-      t.plan(3)
+      t.plan(4)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { threshold: 0 })
@@ -906,12 +921,13 @@ test('It should not compress :', async (t) => {
         method: 'GET'
       })
       t.equal(response.statusCode, 200)
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.same(response.payload, 'event: open\n\nevent: change\ndata: schema\n\n')
     })
 
     t.test('when `Content-Type` reply header value is an invalid type', async (t) => {
-      t.plan(3)
+      t.plan(4)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { threshold: 0 })
@@ -930,6 +946,7 @@ test('It should not compress :', async (t) => {
         }
       })
       t.equal(response.statusCode, 200)
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.equal(response.payload, 'a message')
     })
@@ -950,13 +967,13 @@ test('It should not compress :', async (t) => {
         url: '/',
         method: 'GET'
       })
-      t.equal(response.headers.vary, 'accept-encoding')
       t.equal(response.statusCode, 200)
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
     })
 
     t.test('when `Accept-Encoding` request header is set to `identity`', async (t) => {
-      t.plan(2)
+      t.plan(3)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { global: true, threshold: 0 })
@@ -973,6 +990,7 @@ test('It should not compress :', async (t) => {
         }
       })
       const payload = JSON.parse(response.payload)
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.same({ hello: 'world' }, payload)
     })
@@ -1028,7 +1046,7 @@ test('It should not compress :', async (t) => {
     })
 
     t.test('when `Accept-Encoding` request header is set to `identity and `inflateIfDeflated` is `true``', async (t) => {
-      t.plan(2)
+      t.plan(3)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { global: true, inflateIfDeflated: true, threshold: 0 })
@@ -1045,6 +1063,7 @@ test('It should not compress :', async (t) => {
         }
       })
       const payload = JSON.parse(response.payload)
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.same({ hello: 'world' }, payload)
     })
@@ -1052,7 +1071,7 @@ test('It should not compress :', async (t) => {
 
   t.test('Using `onSend` hook :', async (t) => {
     t.test('when there is no payload', async (t) => {
-      t.plan(3)
+      t.plan(4)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { threshold: 0 })
@@ -1069,12 +1088,13 @@ test('It should not compress :', async (t) => {
         }
       })
       t.equal(response.statusCode, 200)
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.equal(response.payload, '')
     })
 
     t.test('when payload length is smaller than the `threshold` defined value', async (t) => {
-      t.plan(3)
+      t.plan(4)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { threshold: 128 })
@@ -1093,12 +1113,13 @@ test('It should not compress :', async (t) => {
         }
       })
       t.equal(response.statusCode, 200)
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.equal(response.payload, 'a message')
     })
 
     t.test('when `customTypes` is set and does not match `Content-Type` reply header or `mime-db`', async (t) => {
-      t.plan(2)
+      t.plan(3)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { customTypes: /x-user-header$/u })
@@ -1116,12 +1137,13 @@ test('It should not compress :', async (t) => {
           'accept-encoding': 'gzip'
         }
       })
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.equal(response.statusCode, 200)
     })
 
     t.test('when `X-No-Compression` request header is `true`', async (t) => {
-      t.plan(3)
+      t.plan(4)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { threshold: 0 })
@@ -1139,12 +1161,13 @@ test('It should not compress :', async (t) => {
         }
       })
       t.equal(response.statusCode, 200)
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.same(JSON.parse(response.payload), json)
     })
 
     t.test('when `Content-Type` reply header is not set and the content is not detected as a compressible type', async (t) => {
-      t.plan(2)
+      t.plan(3)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { threshold: 0 })
@@ -1167,12 +1190,13 @@ test('It should not compress :', async (t) => {
           'accept-encoding': 'identity'
         }
       })
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.equal(response.payload, JSON.stringify(json))
     })
 
     t.test('when `Content-Type` reply header is a mime type with undefined compressible values', async (t) => {
-      t.plan(3)
+      t.plan(4)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { threshold: 0 })
@@ -1191,12 +1215,13 @@ test('It should not compress :', async (t) => {
         }
       })
       t.equal(response.statusCode, 200)
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.equal(response.payload, 'hello')
     })
 
     t.test('when `Content-Type` reply header value is `text/event-stream`', async (t) => {
-      t.plan(3)
+      t.plan(4)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { threshold: 0 })
@@ -1218,12 +1243,13 @@ test('It should not compress :', async (t) => {
         method: 'GET'
       })
       t.equal(response.statusCode, 200)
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.same(response.payload, 'event: open\n\nevent: change\ndata: schema\n\n')
     })
 
     t.test('when `Content-Type` reply header value is an invalid type', async (t) => {
-      t.plan(3)
+      t.plan(4)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { threshold: 0 })
@@ -1242,6 +1268,7 @@ test('It should not compress :', async (t) => {
         }
       })
       t.equal(response.statusCode, 200)
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.equal(response.payload, 'a message')
     })
@@ -1262,13 +1289,13 @@ test('It should not compress :', async (t) => {
         url: '/',
         method: 'GET'
       })
-      t.equal(response.headers.vary, 'accept-encoding')
       t.equal(response.statusCode, 200)
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
     })
 
     t.test('when `Accept-Encoding` request header is set to `identity`', async (t) => {
-      t.plan(2)
+      t.plan(3)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { global: true, threshold: 0 })
@@ -1285,6 +1312,7 @@ test('It should not compress :', async (t) => {
         }
       })
       const payload = JSON.parse(response.payload)
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.same({ hello: 'world' }, payload)
     })
@@ -1338,7 +1366,7 @@ test('It should not compress :', async (t) => {
     })
 
     t.test('when `Accept-Encoding` request header is set to `identity and `inflateIfDeflated` is `true``', async (t) => {
-      t.plan(2)
+      t.plan(3)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { global: true, inflateIfDeflated: true, threshold: 0 })
@@ -1355,6 +1383,7 @@ test('It should not compress :', async (t) => {
         }
       })
       const payload = JSON.parse(response.payload)
+      t.notOk(response.headers.vary)
       t.notOk(response.headers['content-encoding'])
       t.same({ hello: 'world' }, payload)
     })
@@ -1363,7 +1392,7 @@ test('It should not compress :', async (t) => {
 
 test('It should not double-compress :', async (t) => {
   t.test('when using `reply.compress()` to send an already deflated Stream', async (t) => {
-    t.plan(2)
+    t.plan(3)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true })
@@ -1385,12 +1414,13 @@ test('It should not double-compress :', async (t) => {
     })
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.inflateSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'deflate')
     t.equal(payload.toString('utf-8'), file)
   })
 
   t.test('when using `reply.compress()` to send an already gzipped Stream', async (t) => {
-    t.plan(2)
+    t.plan(3)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true })
@@ -1412,12 +1442,13 @@ test('It should not double-compress :', async (t) => {
     })
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.gunzipSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'gzip')
     t.equal(payload.toString('utf-8'), file)
   })
 
   t.test('when using `onSend` hook to send an already brotli compressed Stream', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true, threshold: 0 })
@@ -1441,13 +1472,14 @@ test('It should not double-compress :', async (t) => {
       }
     })
     const payload = zlib.brotliDecompressSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'br')
     t.equal(response.headers['content-length'], response.rawPayload.length.toString())
     t.equal(payload.toString('utf-8'), file)
   })
 
   t.test('when using `onSend` hook to send an already deflated Stream', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true, threshold: 0 })
@@ -1471,13 +1503,14 @@ test('It should not double-compress :', async (t) => {
       }
     })
     const payload = zlib.inflateSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'deflate')
     t.equal(response.headers['content-length'], response.rawPayload.length.toString())
     t.equal(payload.toString('utf-8'), file)
   })
 
   t.test('when using `onSend` hook to send an already gzipped Stream', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true, threshold: 0 })
@@ -1501,6 +1534,7 @@ test('It should not double-compress :', async (t) => {
       }
     })
     const payload = zlib.gunzipSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'gzip')
     t.equal(response.headers['content-length'], response.rawPayload.length.toString())
     t.equal(payload.toString('utf-8'), file)
@@ -1510,7 +1544,7 @@ test('It should not double-compress :', async (t) => {
 test('It should not compress Stream data and add a `Content-Encoding` reply header :', async (t) => {
   t.test('Using `onSend` hook if `Accept-Encoding` request header value is `identity`', async (t) => {
     t.test('when `inflateIfDeflated` is `true` and `encodings` is not set', async (t) => {
-      t.plan(3)
+      t.plan(4)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { global: true, inflateIfDeflated: true })
@@ -1530,12 +1564,13 @@ test('It should not compress Stream data and add a `Content-Encoding` reply head
       })
       const file = readFileSync('./package.json', 'utf8')
       t.equal(response.statusCode, 200)
+      t.equal(response.headers.vary, 'accept-encoding')
       t.equal(response.headers['content-encoding'], 'identity')
       t.equal(file, response.payload)
     })
 
     t.test('when `inflateIfDeflated` is `true` and `encodings` is set', async (t) => {
-      t.plan(3)
+      t.plan(4)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, {
@@ -1558,6 +1593,7 @@ test('It should not compress Stream data and add a `Content-Encoding` reply head
       })
       const file = readFileSync('./package.json', 'utf-8')
       t.equal(response.statusCode, 200)
+      t.equal(response.headers.vary, 'accept-encoding')
       t.equal(response.headers['content-encoding'], 'identity')
       t.same(response.payload, file)
     })
@@ -1565,7 +1601,7 @@ test('It should not compress Stream data and add a `Content-Encoding` reply head
 
   t.test('Using `reply.compress()` if `Accept-Encoding` request header value is `identity`', async (t) => {
     t.test('when `inflateIfDeflated` is `true` and `encodings` is not set', async (t) => {
-      t.plan(3)
+      t.plan(4)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, { global: true, inflateIfDeflated: true })
@@ -1585,12 +1621,13 @@ test('It should not compress Stream data and add a `Content-Encoding` reply head
       })
       const file = readFileSync('./package.json', 'utf8')
       t.equal(response.statusCode, 200)
+      t.equal(response.headers.vary, 'accept-encoding')
       t.equal(response.headers['content-encoding'], 'identity')
       t.equal(file, response.payload)
     })
 
     t.test('when `inflateIfDeflated` is `true` and `encodings` is set', async (t) => {
-      t.plan(3)
+      t.plan(4)
 
       const fastify = Fastify()
       await fastify.register(compressPlugin, {
@@ -1613,6 +1650,7 @@ test('It should not compress Stream data and add a `Content-Encoding` reply head
       })
       const file = readFileSync('./package.json', 'utf-8')
       t.equal(response.statusCode, 200)
+      t.notOk(response.headers.vary)
       t.equal(response.headers['content-encoding'], 'identity')
       t.same(response.payload, file)
     })
@@ -1620,7 +1658,7 @@ test('It should not compress Stream data and add a `Content-Encoding` reply head
 })
 
 test('It should return a serialized payload when `inflateIfDeflated` is `true` and `X-No-Compression` request header is `true`', async (t) => {
-  t.plan(6)
+  t.plan(8)
 
   const fastify = Fastify()
   await fastify.register(compressPlugin, {
@@ -1648,6 +1686,7 @@ test('It should return a serialized payload when `inflateIfDeflated` is `true` a
     }
   })
   t.equal(one.statusCode, 200)
+  t.notOk(one.headers.vary)
   t.notOk(one.headers['content-encoding'])
   t.same(JSON.parse(one.payload), json)
 
@@ -1659,6 +1698,7 @@ test('It should return a serialized payload when `inflateIfDeflated` is `true` a
     }
   })
   t.equal(two.statusCode, 200)
+  t.notOk(two.headers.vary)
   t.notOk(two.headers['content-encoding'])
   t.equal(two.payload, compressedBufferPayload.toString())
 })
@@ -1737,7 +1777,7 @@ test('It should log an existing error with stream onEnd handler', async (t) => {
 
 test('It should support stream1 :', async (t) => {
   t.test('when using `reply.compress()`', async (t) => {
-    t.plan(2)
+    t.plan(3)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true, threshold: 0 })
@@ -1761,12 +1801,13 @@ test('It should support stream1 :', async (t) => {
       }
     })
     const payload = zlib.gunzipSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'gzip')
     t.same(JSON.parse(payload.toString()), [{ hello: 'world' }, { a: 42 }])
   })
 
   t.test('when using `onSend` hook', async (t) => {
-    t.plan(2)
+    t.plan(3)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true, threshold: 0 })
@@ -1790,6 +1831,7 @@ test('It should support stream1 :', async (t) => {
       }
     })
     const payload = zlib.gunzipSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'gzip')
     t.same(JSON.parse(payload.toString()), [{ hello: 'world' }, { a: 42 }])
   })
@@ -1797,7 +1839,7 @@ test('It should support stream1 :', async (t) => {
 
 test('It should remove `Content-Length` header :', async (t) => {
   t.test('using `reply.compress()`', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true })
@@ -1824,13 +1866,14 @@ test('It should remove `Content-Length` header :', async (t) => {
     })
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.inflateSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'deflate')
     t.notOk(response.headers['content-length'], 'no content length')
     t.equal(payload.toString('utf-8'), file)
   })
 
   t.test('using `reply.compress()` on a Stream when `inflateIfDeflated` is `true` and `X-No-Compression` request header is `true`', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true, inflateIfDeflated: true })
@@ -1851,11 +1894,12 @@ test('It should remove `Content-Length` header :', async (t) => {
     const file = readFileSync('./package.json', 'utf8')
     t.equal(response.statusCode, 200)
     t.notOk(response.headers['content-length'], 'no content length')
+    t.notOk(response.headers.vary)
     t.equal(file, response.payload)
   })
 
   t.test('using `onSend` hook', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true })
@@ -1882,13 +1926,14 @@ test('It should remove `Content-Length` header :', async (t) => {
     })
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.inflateSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'deflate')
     t.notOk(response.headers['content-length'], 'no content length')
     t.equal(payload.toString('utf-8'), file)
   })
 
   t.test('using `onSend` hook on a Stream When `inflateIfDeflated` is `true` and `X-No-Compression` request header is `true`', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true, inflateIfDeflated: true })
@@ -1909,13 +1954,14 @@ test('It should remove `Content-Length` header :', async (t) => {
     const file = readFileSync('./package.json', 'utf8')
     t.equal(response.statusCode, 200)
     t.notOk(response.headers['content-length'], 'no content length')
+    t.notOk(response.headers.vary)
     t.equal(file, response.payload)
   })
 })
 
 test('When `removeContentLengthHeader` is `false`, it should not remove `Content-Length` header :', async (t) => {
   t.test('using `reply.compress()`', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true, removeContentLengthHeader: false })
@@ -1942,13 +1988,14 @@ test('When `removeContentLengthHeader` is `false`, it should not remove `Content
     })
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.inflateSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'deflate')
     t.equal(response.headers['content-length'], payload.length.toString())
     t.equal(payload.toString('utf-8'), file)
   })
 
   t.test('using `onSend` hook', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true, removeContentLengthHeader: false })
@@ -1975,6 +2022,7 @@ test('When `removeContentLengthHeader` is `false`, it should not remove `Content
     })
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.inflateSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'deflate')
     t.equal(response.headers['content-length'], payload.length.toString())
     t.equal(payload.toString('utf-8'), file)
@@ -2317,7 +2365,7 @@ test('When `Accept-Encoding` request header values are not supported and `onUnsu
 
 test('`Accept-Encoding` request header values :', async (t) => {
   t.test('can contain white space', async (t) => {
-    t.plan(2)
+    t.plan(3)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { threshold: 0 })
@@ -2336,12 +2384,13 @@ test('`Accept-Encoding` request header values :', async (t) => {
       }
     })
     const payload = zlib.gunzipSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'gzip')
     t.equal(payload.toString('utf-8'), JSON.stringify(json))
   })
 
   t.test('can contain mixed uppercase and lowercase characters (e.g.: compressing a Stream)', async (t) => {
-    t.plan(2)
+    t.plan(3)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true })
@@ -2361,6 +2410,7 @@ test('`Accept-Encoding` request header values :', async (t) => {
     })
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.gunzipSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'gzip')
     t.equal(payload.toString('utf-8'), file)
   })
@@ -2388,7 +2438,7 @@ test('`Accept-Encoding` request header values :', async (t) => {
   })
 
   t.test('should support `gzip` alias value `x-gzip`', async (t) => {
-    t.plan(2)
+    t.plan(3)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true })
@@ -2410,12 +2460,13 @@ test('`Accept-Encoding` request header values :', async (t) => {
     })
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.gunzipSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'gzip')
     t.equal(payload.toString('utf-8'), file)
   })
 
   t.test('should support quality syntax', async (t) => {
-    t.plan(2)
+    t.plan(3)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true })
@@ -2437,13 +2488,14 @@ test('`Accept-Encoding` request header values :', async (t) => {
     })
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.inflateSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'deflate')
     t.equal(payload.toString('utf-8'), file)
   })
 })
 
 test('It should compress data if `customTypes` is set and matches `Content-Type` reply header value', async (t) => {
-  t.plan(2)
+  t.plan(4)
   const fastify = Fastify()
   await fastify.register(compressPlugin, { customTypes: /x-user-header$/u })
 
@@ -2462,12 +2514,14 @@ test('It should compress data if `customTypes` is set and matches `Content-Type`
   })
   const file = readFileSync('./package.json', 'utf8')
   const payload = zlib.gunzipSync(response.rawPayload)
+  t.equal(response.headers.vary, 'accept-encoding')
   t.equal(response.headers['content-encoding'], 'gzip')
+  t.equal(response.headers.vary, 'accept-encoding')
   t.equal(payload.toString('utf-8'), file)
 })
 
 test('It should compress data if `customTypes` is a function and returns true on the provided `Content-Type` reply header value', async (t) => {
-  t.plan(2)
+  t.plan(3)
   const fastify = Fastify()
   await fastify.register(compressPlugin, { customTypes: value => value === 'application/x-user-header' })
 
@@ -2486,12 +2540,13 @@ test('It should compress data if `customTypes` is a function and returns true on
   })
   const file = readFileSync('./package.json', 'utf8')
   const payload = zlib.gunzipSync(response.rawPayload)
+  t.equal(response.headers.vary, 'accept-encoding')
   t.equal(response.headers['content-encoding'], 'gzip')
   t.equal(payload.toString('utf-8'), file)
 })
 
 test('It should not apply `customTypes` option if the passed value is not a RegExp or Function', async (t) => {
-  t.plan(2)
+  t.plan(3)
 
   const fastify = Fastify()
   await fastify.register(compressPlugin, { customTypes: 'x-user-header' })
@@ -2509,12 +2564,13 @@ test('It should not apply `customTypes` option if the passed value is not a RegE
       'accept-encoding': 'gzip'
     }
   })
+  t.notOk(response.headers.vary)
   t.notOk(response.headers['content-encoding'])
   t.equal(response.statusCode, 200)
 })
 
 test('When `encodings` option is set, it should only use the registered value', async (t) => {
-  t.plan(2)
+  t.plan(3)
 
   const fastify = Fastify()
   await fastify.register(compressPlugin, { encodings: ['deflate'] })
@@ -2530,13 +2586,14 @@ test('When `encodings` option is set, it should only use the registered value', 
       'accept-encoding': 'br,gzip,deflate'
     }
   })
+  t.equal(response.headers.vary, 'accept-encoding')
   t.equal(response.headers['content-encoding'], 'deflate')
   t.equal(response.statusCode, 200)
 })
 
 test('It should send data compressed according to `brotliOptions` :', async (t) => {
   t.test('when using br encoding', async (t) => {
-    t.plan(3)
+    t.plan(4)
     const brotliOptions = {
       params: {
         [zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT,
@@ -2563,6 +2620,7 @@ test('It should send data compressed according to `brotliOptions` :', async (t) 
 
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.brotliDecompressSync(response.rawPayload, brotliOptions)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'br')
     t.equal(payload.toString('utf-8'), file)
 
@@ -2601,7 +2659,7 @@ test('It should send data compressed according to `brotliOptions` :', async (t) 
 
 test('It should send data compressed according to `zlibOptions` :', async (t) => {
   t.test('when using deflate encoding', async (t) => {
-    t.plan(2)
+    t.plan(3)
 
     const zlibOptions = {
       level: 1,
@@ -2628,12 +2686,13 @@ test('It should send data compressed according to `zlibOptions` :', async (t) =>
       }
     })
     const file = readFileSync('./package.json')
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'deflate')
     t.same(response.rawPayload, zlib.deflateSync(file, zlibOptions))
   })
 
   t.test('when using gzip encoding', async (t) => {
-    t.plan(2)
+    t.plan(3)
 
     const zlibOptions = { level: 1 }
 
@@ -2657,6 +2716,7 @@ test('It should send data compressed according to `zlibOptions` :', async (t) =>
       }
     })
     const file = readFileSync('./package.json')
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'gzip')
     t.same(response.rawPayload, zlib.gzipSync(file, zlibOptions))
   })
@@ -2753,7 +2813,7 @@ test('It should not add `accept-encoding` to `Vary` reply header if already pres
 })
 
 test('It should follow the `Accept-Encoding` request header encoding order', async (t) => {
-  t.plan(2)
+  t.plan(3)
 
   const fastify = Fastify()
   await fastify.register(compressPlugin, { global: true })
@@ -2773,12 +2833,13 @@ test('It should follow the `Accept-Encoding` request header encoding order', asy
   })
   const file = readFileSync('./package.json', 'utf8')
   const payload = zlib.brotliDecompressSync(response.rawPayload)
+  t.equal(response.headers.vary, 'accept-encoding')
   t.equal(response.headers['content-encoding'], 'br')
   t.equal(payload.toString('utf-8'), file)
 })
 
 test('It should sort and follow custom `encodings` options', async (t) => {
-  t.plan(2)
+  t.plan(3)
 
   const fastify = Fastify()
   await fastify.register(compressPlugin, {
@@ -2801,12 +2862,13 @@ test('It should sort and follow custom `encodings` options', async (t) => {
   })
   const file = readFileSync('./package.json', 'utf8')
   const payload = zlib.brotliDecompressSync(response.rawPayload)
+  t.equal(response.headers.vary, 'accept-encoding')
   t.equal(response.headers['content-encoding'], 'br')
   t.equal(payload.toString('utf-8'), file)
 })
 
 test('It should sort and prefer the order of custom `encodings` options', async (t) => {
-  t.plan(2)
+  t.plan(3)
 
   const fastify = Fastify()
   await fastify.register(compressPlugin, {
@@ -2830,12 +2892,13 @@ test('It should sort and prefer the order of custom `encodings` options', async 
 
   const file = readFileSync('./package.json', 'utf8')
   const payload = zlib.gunzipSync(response.rawPayload)
+  t.equal(response.headers.vary, 'accept-encoding')
   t.equal(response.headers['content-encoding'], 'gzip')
   t.equal(payload.toString('utf-8'), file)
 })
 
 test('It should sort and follow custom `requestEncodings` options', async (t) => {
-  t.plan(2)
+  t.plan(3)
 
   const fastify = Fastify()
   await fastify.register(compressPlugin, {
@@ -2858,13 +2921,14 @@ test('It should sort and follow custom `requestEncodings` options', async (t) =>
   })
   const file = readFileSync('./package.json', 'utf8')
   const payload = zlib.brotliDecompressSync(response.rawPayload)
+  t.equal(response.headers.vary, 'accept-encoding')
   t.equal(response.headers['content-encoding'], 'br')
   t.equal(payload.toString('utf-8'), file)
 })
 
 test('It should uncompress data when `Accept-Encoding` request header is missing :', async (t) => {
   t.test('using the fallback Node.js `zlib.createInflate()` method', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, {
@@ -2884,12 +2948,13 @@ test('It should uncompress data when `Accept-Encoding` request header is missing
       method: 'GET'
     })
     t.equal(response.statusCode, 200)
+    t.notOk(response.headers.vary)
     t.notOk(response.headers['content-encoding'])
     t.same(JSON.parse('' + response.payload), json)
   })
 
   t.test('using the fallback Node.js `zlib.createGunzip()` method', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, {
@@ -2909,12 +2974,13 @@ test('It should uncompress data when `Accept-Encoding` request header is missing
       method: 'GET'
     })
     t.equal(response.statusCode, 200)
+    t.notOk(response.headers.vary)
     t.notOk(response.headers['content-encoding'])
     t.same(JSON.parse('' + response.payload), json)
   })
 
   t.test('when the data is a deflated Buffer', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, {
@@ -2933,12 +2999,13 @@ test('It should uncompress data when `Accept-Encoding` request header is missing
       method: 'GET'
     })
     t.equal(response.statusCode, 200)
+    t.notOk(response.headers.vary)
     t.notOk(response.headers['content-encoding'])
     t.same(JSON.parse('' + response.payload), json)
   })
 
   t.test('when the data is a gzipped Buffer', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, {
@@ -2957,12 +3024,13 @@ test('It should uncompress data when `Accept-Encoding` request header is missing
       method: 'GET'
     })
     t.equal(response.statusCode, 200)
+    t.notOk(response.headers.vary)
     t.notOk(response.headers['content-encoding'])
     t.same(JSON.parse('' + response.payload), json)
   })
 
   t.test('when the data is a deflated Stream', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, {
@@ -2984,12 +3052,13 @@ test('It should uncompress data when `Accept-Encoding` request header is missing
     })
     const file = readFileSync('./package.json', 'utf8')
     t.equal(response.statusCode, 200)
+    t.notOk(response.headers.vary)
     t.notOk(response.headers['content-encoding'])
     t.equal(response.rawPayload.toString('utf-8'), file)
   })
 
   t.test('when the data is a gzipped Stream', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, {
@@ -3011,12 +3080,13 @@ test('It should uncompress data when `Accept-Encoding` request header is missing
     })
     const file = readFileSync('./package.json', 'utf8')
     t.equal(response.statusCode, 200)
+    t.notOk(response.headers.vary)
     t.notOk(response.headers['content-encoding'])
     t.equal(response.rawPayload.toString('utf-8'), file)
   })
 
   t.test('when the data has been compressed multiple times', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, {
@@ -3039,6 +3109,7 @@ test('It should uncompress data when `Accept-Encoding` request header is missing
       method: 'GET'
     })
     t.equal(response.statusCode, 200)
+    t.notOk(response.headers.vary)
     t.notOk(response.headers['content-encoding'])
     t.same(JSON.parse('' + response.payload), json)
   })
@@ -3172,7 +3243,7 @@ const defaultSupportedContentTypes = [
 
 for (const contentType of defaultSupportedContentTypes) {
   test(`It should compress data if content-type is supported by default, ${contentType}`, async (t) => {
-    t.plan(2)
+    t.plan(3)
     const fastify = Fastify()
     await fastify.register(compressPlugin)
 
@@ -3191,6 +3262,7 @@ for (const contentType of defaultSupportedContentTypes) {
     })
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.gunzipSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'gzip')
     t.equal(payload.toString('utf-8'), file)
   })
@@ -3203,7 +3275,7 @@ const notByDefaultSupportedContentTypes = [
 
 for (const contentType of notByDefaultSupportedContentTypes) {
   test(`It should not compress data if content-type is not supported by default, ${contentType}`, async (t) => {
-    t.plan(2)
+    t.plan(3)
     const fastify = Fastify()
     await fastify.register(compressPlugin)
 
@@ -3221,6 +3293,7 @@ for (const contentType of notByDefaultSupportedContentTypes) {
       }
     })
     const file = readFileSync('./package.json', 'utf8')
+    t.notOk(response.headers.vary)
     t.notOk(response.headers['content-encoding'])
     t.equal(response.rawPayload.toString('utf-8'), file)
   })

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -1015,8 +1015,8 @@ test('It should not compress :', async (t) => {
         }
       })
       const file = readFileSync('./package.json', 'utf8')
-      t.equal(response.headers.vary, 'accept-encoding')
       t.equal(response.statusCode, 200)
+      t.notOk(response.headers.vary)
       t.equal(response.payload, file)
     })
 
@@ -1040,8 +1040,8 @@ test('It should not compress :', async (t) => {
         }
       })
       const file = readFileSync('./package.json', 'utf8')
-      t.equal(response.headers.vary, 'accept-encoding')
       t.equal(response.statusCode, 200)
+      t.notOk(response.headers.vary)
       t.equal(response.payload, file)
     })
 
@@ -1360,8 +1360,8 @@ test('It should not compress :', async (t) => {
         }
       })
       const file = readFileSync('./package.json', 'utf8')
-      t.equal(response.headers.vary, 'accept-encoding')
       t.equal(response.statusCode, 200)
+      t.notOk(response.headers.vary)
       t.equal(response.payload, file)
     })
 
@@ -1468,11 +1468,11 @@ test('It should not double-compress :', async (t) => {
       url: '/',
       method: 'GET',
       headers: {
-        'accept-encoding': 'br,gzip,deflate'
+        'accept-encoding': 'br'
       }
     })
     const payload = zlib.brotliDecompressSync(response.rawPayload)
-    t.equal(response.headers.vary, 'accept-encoding')
+    t.notOk(response.headers.vary)
     t.equal(response.headers['content-encoding'], 'br')
     t.equal(response.headers['content-length'], response.rawPayload.length.toString())
     t.equal(payload.toString('utf-8'), file)
@@ -1499,11 +1499,11 @@ test('It should not double-compress :', async (t) => {
       url: '/',
       method: 'GET',
       headers: {
-        'accept-encoding': 'br,gzip,deflate'
+        'accept-encoding': 'deflate'
       }
     })
     const payload = zlib.inflateSync(response.rawPayload)
-    t.equal(response.headers.vary, 'accept-encoding')
+    t.notOk(response.headers.vary)
     t.equal(response.headers['content-encoding'], 'deflate')
     t.equal(response.headers['content-length'], response.rawPayload.length.toString())
     t.equal(payload.toString('utf-8'), file)
@@ -1534,7 +1534,7 @@ test('It should not double-compress :', async (t) => {
       }
     })
     const payload = zlib.gunzipSync(response.rawPayload)
-    t.equal(response.headers.vary, 'accept-encoding')
+    t.notOk(response.headers.vary)
     t.equal(response.headers['content-encoding'], 'gzip')
     t.equal(response.headers['content-length'], response.rawPayload.length.toString())
     t.equal(payload.toString('utf-8'), file)
@@ -1564,7 +1564,7 @@ test('It should not compress Stream data and add a `Content-Encoding` reply head
       })
       const file = readFileSync('./package.json', 'utf8')
       t.equal(response.statusCode, 200)
-      t.equal(response.headers.vary, 'accept-encoding')
+      t.notOk(response.headers.vary)
       t.equal(response.headers['content-encoding'], 'identity')
       t.equal(file, response.payload)
     })
@@ -1593,7 +1593,7 @@ test('It should not compress Stream data and add a `Content-Encoding` reply head
       })
       const file = readFileSync('./package.json', 'utf-8')
       t.equal(response.statusCode, 200)
-      t.equal(response.headers.vary, 'accept-encoding')
+      t.notOk(response.headers.vary)
       t.equal(response.headers['content-encoding'], 'identity')
       t.same(response.payload, file)
     })
@@ -1621,7 +1621,7 @@ test('It should not compress Stream data and add a `Content-Encoding` reply head
       })
       const file = readFileSync('./package.json', 'utf8')
       t.equal(response.statusCode, 200)
-      t.equal(response.headers.vary, 'accept-encoding')
+      t.notOk(response.headers.vary)
       t.equal(response.headers['content-encoding'], 'identity')
       t.equal(file, response.payload)
     })
@@ -1893,8 +1893,8 @@ test('It should remove `Content-Length` header :', async (t) => {
     })
     const file = readFileSync('./package.json', 'utf8')
     t.equal(response.statusCode, 200)
-    t.notOk(response.headers['content-length'], 'no content length')
     t.notOk(response.headers.vary)
+    t.notOk(response.headers['content-length'], 'no content length')
     t.equal(file, response.payload)
   })
 
@@ -1953,8 +1953,8 @@ test('It should remove `Content-Length` header :', async (t) => {
     })
     const file = readFileSync('./package.json', 'utf8')
     t.equal(response.statusCode, 200)
-    t.notOk(response.headers['content-length'], 'no content length')
     t.notOk(response.headers.vary)
+    t.notOk(response.headers['content-length'], 'no content length')
     t.equal(file, response.payload)
   })
 })
@@ -2495,7 +2495,7 @@ test('`Accept-Encoding` request header values :', async (t) => {
 })
 
 test('It should compress data if `customTypes` is set and matches `Content-Type` reply header value', async (t) => {
-  t.plan(4)
+  t.plan(3)
   const fastify = Fastify()
   await fastify.register(compressPlugin, { customTypes: /x-user-header$/u })
 
@@ -2516,7 +2516,6 @@ test('It should compress data if `customTypes` is set and matches `Content-Type`
   const payload = zlib.gunzipSync(response.rawPayload)
   t.equal(response.headers.vary, 'accept-encoding')
   t.equal(response.headers['content-encoding'], 'gzip')
-  t.equal(response.headers.vary, 'accept-encoding')
   t.equal(payload.toString('utf-8'), file)
 })
 
@@ -3142,7 +3141,7 @@ test('When `onUnsupportedEncoding` is set and the `Accept-Encoding` request head
       }
     })
     t.equal(response.statusCode, 406)
-    t.equal(response.headers.vary, 'accept-encoding')
+    t.notOk(response.headers.vary)
     t.same(JSON.parse(response.payload), { hello: 'hello' })
   })
 

--- a/test/routes-compress.test.js
+++ b/test/routes-compress.test.js
@@ -8,7 +8,7 @@ const compressPlugin = require('../index')
 
 test('When using routes `compress` settings :', async (t) => {
   t.test('it should compress data using the route custom provided `createDeflate` method', async (t) => {
-    t.plan(10)
+    t.plan(12)
 
     let usedCustomGlobal = false
     let usedCustom = false
@@ -44,6 +44,7 @@ test('When using routes `compress` settings :', async (t) => {
 
       const file = readFileSync('./package.json', 'utf8')
       const payload = zlib.inflateSync(response.rawPayload)
+      t.equal(response.headers.vary, 'accept-encoding')
       t.equal(response.headers['content-encoding'], 'deflate')
       t.notOk(response.headers['content-length'], 'no content length')
       t.equal(payload.toString('utf-8'), file)
@@ -64,13 +65,14 @@ test('When using routes `compress` settings :', async (t) => {
 
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.inflateSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'deflate')
     t.notOk(response.headers['content-length'], 'no content length')
     t.equal(payload.toString('utf-8'), file)
   })
 
   t.test('it should compress data using the route custom provided `createGzip` method', async (t) => {
-    t.plan(8)
+    t.plan(10)
 
     let usedCustomGlobal = false
     let usedCustom = false
@@ -104,6 +106,7 @@ test('When using routes `compress` settings :', async (t) => {
 
       const file = readFileSync('./package.json', 'utf8')
       const payload = zlib.gunzipSync(response.rawPayload)
+      t.equal(response.headers.vary, 'accept-encoding')
       t.equal(response.headers['content-encoding'], 'gzip')
       t.equal(payload.toString('utf-8'), file)
 
@@ -123,12 +126,13 @@ test('When using routes `compress` settings :', async (t) => {
 
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.gunzipSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'gzip')
     t.equal(payload.toString('utf-8'), file)
   })
 
   t.test('it should not compress data when `global` is `false` unless `compress` routes settings have been set up', async (t) => {
-    t.plan(9)
+    t.plan(12)
 
     let usedCustom = false
     const customZlib = { createGzip: () => (usedCustom = true) && zlib.createGzip() }
@@ -165,8 +169,8 @@ test('When using routes `compress` settings :', async (t) => {
       }
     }).then((response) => {
       t.equal(usedCustom, false)
-
-      t.equal(response.headers['content-encoding'], undefined)
+      t.notOk(response.headers.vary)
+      t.notOk(response.headers['content-encoding'])
       t.equal(response.rawPayload.toString('utf-8'), JSON.stringify({ foo: 1 }))
 
       usedCustom = false
@@ -183,6 +187,7 @@ test('When using routes `compress` settings :', async (t) => {
 
       const file = readFileSync('./package.json', 'utf8')
       const payload = zlib.gunzipSync(response.rawPayload)
+      t.equal(response.headers.vary, 'accept-encoding')
       t.equal(response.headers['content-encoding'], 'gzip')
       t.equal(payload.toString('utf-8'), file)
     })
@@ -195,12 +200,13 @@ test('When using routes `compress` settings :', async (t) => {
       }
     })
     const payload = zlib.gunzipSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'gzip')
     t.equal(payload.toString('utf-8'), JSON.stringify({ foo: 1 }))
   })
 
   t.test('it should not compress data when route `compress` option is set to `false`', async (t) => {
-    t.plan(2)
+    t.plan(3)
 
     const content = { message: 'Hello World!' }
 
@@ -220,7 +226,8 @@ test('When using routes `compress` settings :', async (t) => {
         'accept-encoding': 'gzip'
       }
     })
-    t.equal(response.headers['content-encoding'], undefined)
+    t.notOk(response.headers.vary)
+    t.notOk(response.headers['content-encoding'])
     t.equal(response.rawPayload.toString('utf-8'), JSON.stringify(content))
   })
 
@@ -244,7 +251,7 @@ test('When using routes `compress` settings :', async (t) => {
 
 test('When `compress.removeContentLengthHeader` is `false`, it should not remove `Content-Length` header :', async (t) => {
   t.test('using `reply.compress()`', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true })
@@ -273,13 +280,14 @@ test('When `compress.removeContentLengthHeader` is `false`, it should not remove
     })
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.inflateSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'deflate')
     t.equal(response.headers['content-length'], payload.length.toString())
     t.equal(payload.toString('utf-8'), file)
   })
 
   t.test('using `onSend` hook', async (t) => {
-    t.plan(3)
+    t.plan(4)
 
     const fastify = Fastify()
     await fastify.register(compressPlugin, { global: true })
@@ -308,6 +316,7 @@ test('When `compress.removeContentLengthHeader` is `false`, it should not remove
     })
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.inflateSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'deflate')
     t.equal(response.headers['content-length'], payload.length.toString())
     t.equal(payload.toString('utf-8'), file)
@@ -316,7 +325,7 @@ test('When `compress.removeContentLengthHeader` is `false`, it should not remove
 
 test('When using the old routes `{ config: compress }` option :', async (t) => {
   t.test('it should compress data using the route custom provided `createGzip` method', async (t) => {
-    t.plan(8)
+    t.plan(10)
 
     let usedCustomGlobal = false
     let usedCustom = false
@@ -354,6 +363,7 @@ test('When using the old routes `{ config: compress }` option :', async (t) => {
 
       const file = readFileSync('./package.json', 'utf8')
       const payload = zlib.gunzipSync(response.rawPayload)
+      t.equal(response.headers.vary, 'accept-encoding')
       t.equal(response.headers['content-encoding'], 'gzip')
       t.equal(payload.toString('utf-8'), file)
 
@@ -373,6 +383,7 @@ test('When using the old routes `{ config: compress }` option :', async (t) => {
 
     const file = readFileSync('./package.json', 'utf8')
     const payload = zlib.gunzipSync(response.rawPayload)
+    t.equal(response.headers.vary, 'accept-encoding')
     t.equal(response.headers['content-encoding'], 'gzip')
     t.equal(payload.toString('utf-8'), file)
   })


### PR DESCRIPTION
The PR is about to fix a bug reported by #279 
The PR will set response header `vary` only when compression actually happened

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/master/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/master/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/master/CODE_OF_CONDUCT.md)
