### PR TITLE
types: use `node:` prefix for builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Note that the compress method is configured with either the per route parameters
 the plugin was defined as global.
 
 ```javascript
-import fs from 'fs'
+import fs from 'node:fs'
 import fastify from 'fastify'
 
 const app = fastify()

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "c8": "^10.1.2",
     "fastify": "^5.0.0",
     "jsonstream": "^1.0.3",
-    "neostandard": "^0.11.9",
+    "neostandard": "^0.12.0",
     "tsd": "^0.31.0",
     "typescript": "~5.7.2"
   },

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -6,8 +6,8 @@ import {
   RawServerBase,
   RawServerDefault
 } from 'fastify'
-import { Stream } from 'stream'
-import { BrotliOptions, ZlibOptions } from 'zlib'
+import { Stream } from 'node:stream'
+import { BrotliOptions, ZlibOptions } from 'node:zlib'
 
 declare module 'fastify' {
   export interface FastifyContextConfig {

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -1,7 +1,7 @@
 import fastify, { FastifyInstance } from 'fastify'
-import { createReadStream } from 'fs'
+import { createReadStream } from 'node:fs'
 import { expectError, expectType } from 'tsd'
-import * as zlib from 'zlib'
+import * as zlib from 'node:zlib'
 import fastifyCompress, { FastifyCompressOptions } from '..'
 
 const stream = createReadStream('./package.json')


### PR DESCRIPTION
See https://github.com/fastify/fastify/pull/5896. This is a batch PR, so may have some issues. Please review changes.