### PR TITLE
build(deps-dev): add eslint, peer dep of neostandard

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@types/node": "^22.0.0",
     "adm-zip": "^0.5.12",
     "c8": "^10.1.2",
+    "eslint": "^9.17.0",
     "fastify": "^5.0.0",
     "jsonstream": "^1.0.3",
     "neostandard": "^0.12.0",


### PR DESCRIPTION
Missing peer dep. This is a batch PR, so may have some issues. Please review changes.