### PR TITLE
fix: prevents fastify-compress from trying to work with something it cannot

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,6 +147,7 @@ yarn.lock
 # editor files
 .vscode
 .idea
+.zed
 
 #tap files
 .tap/

--- a/README.md
+++ b/README.md
@@ -268,6 +268,19 @@ By default, `@fastify/compress` removes the reply `Content-Length` header. Chang
   )
 ```
 
+### isCompressiblePayload
+A function to determine whether a non-stream payload can be compressed. By default, only `Buffer` and `string` payloads are considered compressible. If the payload is not compressible, it is passed through without compression.
+
+This can be useful when other plugins replace the payload in an `onSend` hook with a type that `Buffer.byteLength` cannot handle.
+
+```js
+  await server.register(fastifyCompress, {
+    isCompressiblePayload: (payload) => {
+      return Buffer.isBuffer(payload) || typeof payload === 'string'
+    }
+  })
+```
+
 ## Usage - Decompress request payloads
 This plugin adds a `preParsing` hook to decompress the request payload based on the `content-encoding` request header.
 
@@ -393,6 +406,12 @@ await fastify.register(
   }
 )
 ```
+
+## Gotchas
+
+When you, or another plugin modify the request body, it's possible that `@fastify/compress` will recieve a response body that it doesn't know what to do with. If this happens when you call the `compress` function directly, it'll make a best effort at compressing the payload anyway, by using the fastify `serialize` function on whatever is passed.
+
+If the response is being compressed by the global hook, and it inadvertedly receives something it doesn't know what to do with, it'll ignore it completely and respond with the uncompressed payload. This to prevent inadvertedly breaking whole servers with hard to find bugs.
 
 ## Acknowledgments
 

--- a/index.js
+++ b/index.js
@@ -173,6 +173,10 @@ function processCompressParams (opts) {
       .sort((a, b) => opts.encodings.indexOf(a) - opts.encodings.indexOf(b))
     : supportedEncodings
 
+  params.isCompressiblePayload = typeof opts.isCompressiblePayload === 'function'
+    ? opts.isCompressiblePayload
+    : isCompressiblePayload
+
   return params
 }
 
@@ -301,6 +305,9 @@ function buildRouteCompress (_fastify, params, routeOptions, decorateOnly) {
       if (isWebReadableStream(payload)) {
         payload = webStreamToNodeReadable(payload)
       } else {
+        if (!params.isCompressiblePayload(payload)) {
+          return next(null, payload)
+        }
         if (Buffer.byteLength(payload) < params.threshold) {
           return next()
         }
@@ -429,7 +436,7 @@ function compress (params) {
 
       if (isWebReadableStream(payload)) {
         payload = webStreamToNodeReadable(payload)
-      } else if (!Buffer.isBuffer(payload) && typeof payload !== 'string') {
+      } else if (!params.isCompressiblePayload(payload)) {
         payload = this.serialize(payload)
       }
     }
@@ -519,6 +526,13 @@ function getEncodingHeader (encodings, request) {
   } else {
     return undefined
   }
+}
+
+function isCompressiblePayload (payload) {
+  // By the time payloads reach this point, Fastify has already serialized
+  // objects/arrays/etc to strings, so we only need to check for the actual
+  // types that make it through: Buffer and string
+  return Buffer.isBuffer(payload) || typeof payload === 'string'
 }
 
 function shouldCompress (type, compressibleTypes) {

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -3548,3 +3548,102 @@ test('It should demonstrate globalDecompression controls decompression independe
   t.assert.equal(response.statusCode, 400)
   t.assert.ok(response.body.includes('Content-Length') || response.body.includes('Bad Request'))
 })
+
+test('It should skip compression when isCompressiblePayload returns false', async (t) => {
+  t.plan(3)
+
+  let isCompressibleCalled = false
+  const testIsCompressiblePayload = (payload) => {
+    isCompressibleCalled = true
+    // Reject all payloads regardless of type
+    return false
+  }
+
+  const fastify = Fastify()
+  await fastify.register(compressPlugin, {
+    isCompressiblePayload: testIsCompressiblePayload,
+    threshold: 0
+  })
+
+  fastify.get('/', (_request, reply) => {
+    reply.header('content-type', 'application/json')
+    reply.send('{"message": "test"}')
+  })
+
+  const response = await fastify.inject({
+    url: '/',
+    method: 'GET',
+    headers: {
+      'accept-encoding': 'gzip, deflate, br'
+    }
+  })
+
+  t.assert.equal(response.statusCode, 200)
+  t.assert.equal(response.headers['content-encoding'], undefined)
+  t.assert.equal(isCompressibleCalled, true)
+})
+
+test('It should serialize and compress objects when reply.compress() receives non-compressible objects', async (t) => {
+  t.plan(2)
+
+  const fastify = Fastify()
+  await fastify.register(compressPlugin, {
+    threshold: 0 // Ensure even small payloads get compressed
+  })
+
+  // Create a larger object to ensure it exceeds any default threshold
+  const objectPayload = {
+    message: 'test data'.repeat(100),
+    value: 42,
+    description: 'A test object that should be large enough to trigger compression after serialization'.repeat(10)
+  }
+
+  fastify.get('/', (_request, reply) => {
+    reply.header('content-type', 'application/json')
+    // The compress function should now serialize the object and then compress it
+    reply.compress(objectPayload)
+  })
+
+  const response = await fastify.inject({
+    url: '/',
+    method: 'GET',
+    headers: {
+      'accept-encoding': 'gzip, deflate, br'
+    }
+  })
+
+  t.assert.equal(response.statusCode, 200)
+  // The response should be compressed since the object gets serialized to a string
+  t.assert.ok(['gzip', 'deflate', 'br'].includes(response.headers['content-encoding']))
+})
+
+test('It should stream Response body when using reply.compress() with a fetch Response', async (t) => {
+  t.plan(3)
+
+  const fastify = Fastify()
+  await fastify.register(compressPlugin, {
+    threshold: 0
+  })
+
+  const testContent = 'test content for compression'
+  const responseObject = new Response(testContent)
+
+  fastify.get('/', (_request, reply) => {
+    reply.header('content-type', 'text/plain')
+    reply.compress(responseObject)
+  })
+
+  const response = await fastify.inject({
+    url: '/',
+    method: 'GET',
+    headers: {
+      'accept-encoding': 'gzip'
+    }
+  })
+
+  t.assert.equal(response.statusCode, 200)
+  t.assert.equal(response.headers['content-encoding'], 'gzip')
+
+  const decompressed = zlib.gunzipSync(Buffer.from(response.rawPayload)).toString('utf8')
+  t.assert.equal(decompressed, testContent)
+})


### PR DESCRIPTION
I'm still trying to figure out *how* it happens (something involving tRPC responses), but for now I'll be happy if I can stop compress from trying to compress something it can't.

I assume the differing behavior between the automatic compression (hook), and manual compression (the `compress` function) is because you don't want to mess with payloads (e.g. serialize them) unless people explicitly call the compress function. I've kept that behavior, and the global hook simply doesn't compress if it gets something it cannot deal with, while the compress function, well, it already serialized things, so it might cause wonky behavior if you pass it a Response object.

Tests:

- Test that `Response` objects are not compressed on global hook
- Test that objects get serialized normally when using `compress`
- Test that `Response` objects are compressed after being serialized to `{}` with the `compress` function.

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
