### PR TITLE
feat: allow enabling and disabling compression and decompression separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ await fastify.register(
   { global: false }
 )
 ```
+
+If only compression, or only decompression is desired, you can use the `globalCompression` or `globalDecompression` config flags to turn either off specifically (because the global hook is enabled by default).
+
+```js
+await fastify.register(
+  import('@fastify/compress'),
+  // only decompress compressed incoming requests
+  { globalCompression: false }
+)
+```
+
 Fastify encapsulation can be used to set global compression but run it only in a subset of routes by wrapping them inside a plugin.
 
 > ℹ️ Note: If using `@fastify/compress` plugin together with `@fastify/static` plugin, `@fastify/compress` must be registered (with *global hook*) **before** registering `@fastify/static`.

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ await fastify.register(
 )
 ```
 
-If only compression, or only decompression is desired, you can use the `globalCompression` or `globalDecompression` config flags to turn either off specifically (because the global hook is enabled by default).
+If only compression or decompression is required, set the `globalCompression` or `globalDecompression` config flags to `false` respectively (both are `true` by default).
 
 ```js
 await fastify.register(

--- a/README.md
+++ b/README.md
@@ -62,8 +62,14 @@ If only compression or decompression is required, set the `globalCompression` or
 ```js
 await fastify.register(
   import('@fastify/compress'),
-  // only decompress compressed incoming requests
+  // Disable compression but keep decompression enabled (default behavior for globalDecompression is true)
   { globalCompression: false }
+)
+
+// Disable decompression but keep compression enabled
+await fastify.register(
+  import('@fastify/compress'),
+  { globalDecompression: false }
 )
 ```
 

--- a/index.js
+++ b/index.js
@@ -124,7 +124,9 @@ function processCompressParams (opts) {
   }
 
   const params = {
-    global: (typeof opts.global === 'boolean') ? opts.global : true
+    global: (typeof opts.globalCompression === 'boolean')
+      ? opts.globalCompression
+      : (typeof opts.global === 'boolean') ? opts.global : true
   }
 
   params.removeContentLengthHeader = typeof opts.removeContentLengthHeader === 'boolean' ? opts.removeContentLengthHeader : true
@@ -173,7 +175,9 @@ function processDecompressParams (opts) {
   const customZlib = opts.zlib || zlib
 
   const params = {
-    global: (typeof opts.global === 'boolean') ? opts.global : true,
+    global: (typeof opts.globalDecompression === 'boolean')
+      ? opts.globalDecompression
+      : (typeof opts.global === 'boolean') ? opts.global : true,
     onUnsupportedRequestEncoding: opts.onUnsupportedRequestEncoding,
     onInvalidRequestPayload: opts.onInvalidRequestPayload,
     decompressStream: {

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -3298,3 +3298,152 @@ for (const contentType of notByDefaultSupportedContentTypes) {
     t.assert.equal(response.rawPayload.toString('utf-8'), file)
   })
 }
+
+test('It should support separate globalCompression and globalDecompression settings', async (t) => {
+  t.plan(3)
+
+  // Test case: disable compression but enable decompression globally
+  const fastify = Fastify()
+  await fastify.register(compressPlugin, {
+    globalCompression: false,
+    globalDecompression: true
+  })
+
+  const testData = { message: 'test data for decompression only' }
+
+  fastify.get('/', (request, reply) => {
+    reply.send(testData)
+  })
+
+  // Test that compression is disabled
+  const getResponse = await fastify.inject({
+    url: '/',
+    method: 'GET',
+    headers: {
+      'accept-encoding': 'gzip, deflate, br'
+    }
+  })
+
+  t.assert.equal(getResponse.statusCode, 200)
+  // No compression should happen since globalCompression is false
+  t.assert.equal(getResponse.headers['content-encoding'], undefined)
+  t.assert.deepEqual(getResponse.json(), testData)
+})
+
+test('It should enable decompression when globalDecompression is true', async (t) => {
+  t.plan(2)
+
+  // Test case: enable decompression globally
+  const fastify = Fastify()
+  await fastify.register(compressPlugin, {
+    globalCompression: false,
+    globalDecompression: true
+  })
+
+  // Create a compressed request payload to test decompression
+  const compressedPayload = zlib.gzipSync(JSON.stringify({ input: 'compressed data' }))
+
+  fastify.post('/', (request, reply) => {
+    // This should be decompressed automatically
+    reply.send({ received: request.body })
+  })
+
+  // Test that decompression is enabled
+  const postResponse = await fastify.inject({
+    url: '/',
+    method: 'POST',
+    headers: {
+      'content-encoding': 'gzip',
+      'content-type': 'application/json'
+    },
+    payload: compressedPayload
+  })
+
+  t.assert.equal(postResponse.statusCode, 200)
+  // Decompression should work since globalDecompression is true
+  t.assert.deepEqual(postResponse.json(), { received: { input: 'compressed data' } })
+})
+
+test('It should fall back to global option when specific options are not provided', async (t) => {
+  t.plan(2)
+
+  // Test that global: false affects both compression and decompression
+  const fastify = Fastify()
+  await fastify.register(compressPlugin, {
+    global: false
+  })
+
+  const testData = { message: 'test data' }
+
+  fastify.get('/', (request, reply) => {
+    reply.send(testData)
+  })
+
+  const response = await fastify.inject({
+    url: '/',
+    method: 'GET',
+    headers: {
+      'accept-encoding': 'gzip, deflate, br'
+    }
+  })
+
+  t.assert.equal(response.statusCode, 200)
+  // No compression should happen since global is false
+  t.assert.equal(response.headers['content-encoding'], undefined)
+})
+
+test('It should demonstrate globalCompression overrides global setting', async (t) => {
+  t.plan(2)
+
+  // Test that globalCompression: true overrides global: false
+  const fastify = Fastify()
+  await fastify.register(compressPlugin, {
+    global: false,
+    globalCompression: true,
+    threshold: 0
+  })
+
+  fastify.get('/', (request, reply) => {
+    reply.send({ message: 'globalCompression overrides global' })
+  })
+
+  const response = await fastify.inject({
+    url: '/',
+    method: 'GET',
+    headers: { 'accept-encoding': 'gzip' }
+  })
+
+  t.assert.equal(response.statusCode, 200)
+  t.assert.equal(response.headers['content-encoding'], 'gzip') // Compression enabled despite global: false
+})
+
+test('It should demonstrate globalDecompression controls decompression independently', async (t) => {
+  t.plan(2)
+
+  // Test globalDecompression: false disables decompression even with global: true
+  const fastify = Fastify()
+  await fastify.register(compressPlugin, {
+    global: true,
+    globalDecompression: false
+  })
+
+  const compressedPayload = zlib.gzipSync(JSON.stringify({ test: 'decompression' }))
+
+  fastify.post('/', (request, reply) => {
+    reply.send({ received: request.body })
+  })
+
+  const response = await fastify.inject({
+    url: '/',
+    method: 'POST',
+    headers: {
+      'content-encoding': 'gzip',
+      'content-type': 'application/json'
+    },
+    payload: compressedPayload
+  })
+
+  // Should get 400 error since decompression is disabled and compressed data can't be parsed
+  t.assert.equal(response.statusCode, 400)
+  t.assert.ok(response.body.includes('Content-Length') || response.body.includes('Bad Request'))
+})

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -77,6 +77,8 @@ declare namespace fastifyCompress {
     encodings?: EncodingToken[];
     forceRequestEncoding?: EncodingToken;
     global?: boolean;
+    globalDecompression?: boolean;
+    globalCompression?: boolean;
     inflateIfDeflated?: boolean;
     onInvalidRequestPayload?: (encoding: string, request: FastifyRequest, error: Error) => Error | undefined | null;
     onUnsupportedEncoding?: (encoding: string, request: FastifyRequest, reply: FastifyReply) => string | Buffer | Stream;


### PR DESCRIPTION
This splits out the keys for enabling decompression and compression. I basically wanted to use the library to decompress incoming requests only, but got free compression for my trouble (which caused the issue that I had in the other PR I submitted).

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
