### PR TITLE
fix: ensure that compress stream stays open

### DIFF
--- a/index.js
+++ b/index.js
@@ -447,7 +447,7 @@ function compress (params) {
 
     stream = zipStream(params.compressStream, encoding)
     pump(payload, stream, onEnd.bind(this))
-    this.send(stream)
+    return this.send(stream)
   }
 }
 

--- a/test/regression/issue-350.test.js
+++ b/test/regression/issue-350.test.js
@@ -1,0 +1,43 @@
+'use strict'
+
+const { test } = require('node:test')
+const zlib = require('node:zlib')
+const Fastify = require('fastify')
+const fastifyCompress = require('../..')
+
+const largeJsonString = JSON.stringify({
+  text: 'Lorem ipsum dolor sit amet. '.repeat(2048),
+})
+
+async function routes (fastify) {
+  fastify.route({
+    method: 'GET',
+    url: '/api/compress-test',
+    handler: async function (_request, reply) {
+      reply.type('application/json')
+      return reply.compress(largeJsonString)
+    }
+  })
+}
+
+test('should compress large payload without premature close', async (t) => {
+  const fastify = Fastify()
+  await fastify.register(fastifyCompress, { encodings: ['gzip'], global: true })
+  await fastify.register(routes)
+
+  const response = await fastify.inject({
+    url: '/api/compress-test',
+    method: 'GET',
+    headers: { 'accept-encoding': 'gzip' }
+  })
+
+  t.assert.equal(response.statusCode, 200)
+  t.assert.equal(response.headers['content-encoding'], 'gzip')
+  t.assert.ok(
+    response.rawPayload.length > 0,
+    `Expected compressed response body, got ${response.rawPayload.length} bytes`
+  )
+
+  const decompressed = zlib.gunzipSync(response.rawPayload)
+  t.assert.equal(decompressed.toString('utf-8'), largeJsonString)
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

I don't see the need to update any documentation for this bugfix. Please let me know if I have missed something.

Fixes:
- https://github.com/fastify/fastify-compress/issues/350