### PR TITLE
fix: invalid content length error for compressed requests

### DIFF
--- a/index.js
+++ b/index.js
@@ -369,13 +369,13 @@ function buildRouteDecompress (_fastify, params, routeOptions) {
 
     // Prepare decompression - If there is a decompress error, prepare the error for fastify handing
     const decompresser = params.decompressStream[encoding]()
-    decompresser.receivedEncodedLength = 0
     decompresser.on('error', onDecompressError.bind(this, request, params, encoding))
     decompresser.pause()
 
-    // Track length of encoded length to handle receivedEncodedLength
-    raw.on('data', trackEncodedLength.bind(decompresser))
-    raw.on('end', removeEncodedLengthTracking)
+    // Content-Length reflects the compressed wire size. After decompression it
+    // no longer matches the body size that Fastify validates against, causing
+    // FST_ERR_CTP_INVALID_CONTENT_LENGTH. Remove it so Fastify skips the check.
+    delete request.raw.headers['content-length']
 
     pipeline(raw, decompresser, () => {
       // Cleanup callback - decompression errors are handled by decompresser's error handler
@@ -473,15 +473,6 @@ function onEnd (err) {
   if (err && err.message !== 'premature close') {
     this.log.error(err)
   }
-}
-
-function trackEncodedLength (chunk) {
-  this.receivedEncodedLength += chunk.length
-}
-
-function removeEncodedLengthTracking () {
-  this.removeListener('data', trackEncodedLength)
-  this.removeListener('end', removeEncodedLengthTracking)
 }
 
 function onDecompressError (request, params, encoding, error) {

--- a/test/regression/issue-191.test.js
+++ b/test/regression/issue-191.test.js
@@ -1,0 +1,116 @@
+'use strict'
+
+// Regression test for https://github.com/fastify/fastify-compress/issues/191
+//
+// When a client sends a compressed request body and includes a Content-Length
+// header reflecting the *compressed* byte size, Fastify's body parser would
+// compare that compressed size against the decompressed body size and raise
+// FST_ERR_CTP_INVALID_CONTENT_LENGTH.
+//
+// The fix: delete the Content-Length header inside the preParsing decompression
+// hook so Fastify skips the size check entirely.
+
+const { test, describe } = require('node:test')
+const zlib = require('node:zlib')
+const http = require('node:http')
+const Fastify = require('fastify')
+const compressPlugin = require('../..')
+
+// Makes a real HTTP POST request with a pre-compressed body and an explicit
+// Content-Length set to the *compressed* byte size (as real clients do).
+function postCompressed ({ port, body, encoding }) {
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: '127.0.0.1',
+        port,
+        path: '/',
+        method: 'POST',
+        headers: {
+          'content-type': 'application/json',
+          'content-encoding': encoding,
+          'content-length': String(body.length),
+        },
+      },
+      (res) => {
+        let data = ''
+        res.on('data', (chunk) => { data += chunk })
+        res.on('end', () => resolve({ statusCode: res.statusCode, body: data }))
+      }
+    )
+    req.once('error', reject)
+    req.end(body)
+  })
+}
+
+const payload = JSON.stringify({ name: '@fastify/compress' })
+
+describe('regression issue-191: compressed request with Content-Length set to compressed size', async () => {
+  test('should decompress gzip request without FST_ERR_CTP_INVALID_CONTENT_LENGTH', async (t) => {
+    t.plan(2)
+
+    const fastify = Fastify()
+    t.after(() => fastify.close())
+    await fastify.register(compressPlugin)
+    fastify.post('/', (request, reply) => { reply.send(request.body.name) })
+    await fastify.listen({ port: 0, host: '127.0.0.1' })
+    const port = fastify.server.address().port
+
+    const compressed = zlib.gzipSync(payload)
+    const response = await postCompressed({ port, body: compressed, encoding: 'gzip' })
+
+    t.assert.equal(response.statusCode, 200)
+    t.assert.equal(response.body, '@fastify/compress')
+  })
+
+  test('should decompress deflate request without FST_ERR_CTP_INVALID_CONTENT_LENGTH', async (t) => {
+    t.plan(2)
+
+    const fastify = Fastify()
+    t.after(() => fastify.close())
+    await fastify.register(compressPlugin)
+    fastify.post('/', (request, reply) => { reply.send(request.body.name) })
+    await fastify.listen({ port: 0, host: '127.0.0.1' })
+    const port = fastify.server.address().port
+
+    const compressed = zlib.deflateSync(payload)
+    const response = await postCompressed({ port, body: compressed, encoding: 'deflate' })
+
+    t.assert.equal(response.statusCode, 200)
+    t.assert.equal(response.body, '@fastify/compress')
+  })
+
+  test('should decompress brotli request without FST_ERR_CTP_INVALID_CONTENT_LENGTH', async (t) => {
+    t.plan(2)
+
+    const fastify = Fastify()
+    t.after(() => fastify.close())
+    await fastify.register(compressPlugin)
+    fastify.post('/', (request, reply) => { reply.send(request.body.name) })
+    await fastify.listen({ port: 0, host: '127.0.0.1' })
+    const port = fastify.server.address().port
+
+    const compressed = zlib.brotliCompressSync(payload)
+    const response = await postCompressed({ port, body: compressed, encoding: 'br' })
+
+    t.assert.equal(response.statusCode, 200)
+    t.assert.equal(response.body, '@fastify/compress')
+  })
+
+  test('should decompress gzip request at route level without FST_ERR_CTP_INVALID_CONTENT_LENGTH', async (t) => {
+    t.plan(2)
+
+    const fastify = Fastify()
+    t.after(() => fastify.close())
+    await fastify.register(compressPlugin, { global: false })
+    fastify.post('/', { decompress: {} }, (request, reply) => { reply.send(request.body.name) })
+    await fastify.listen({ port: 0, host: '127.0.0.1' })
+    const port = fastify.server.address().port
+
+    const compressed = zlib.gzipSync(payload)
+    const response = await postCompressed({ port, body: compressed, encoding: 'gzip' })
+
+    t.assert.equal(response.statusCode, 200)
+    t.assert.equal(response.body, '@fastify/compress')
+  })
+})


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

Fixes https://github.com/fastify/fastify-compress/issues/191

This is a long-standing issue. I'm not 100% sure this the right thing to do ™️ though. The other alternative has been to build a `preParsing` function in fastify that runs before registering this plugin that does essentially the same thing and runs the decompression logic itself.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)