### PR TITLE
test: exercise async handler + compress onSend interaction

### DIFF
--- a/test/routes-compress.test.js
+++ b/test/routes-compress.test.js
@@ -470,3 +470,61 @@ test('reply.compress should handle Web ReadableStream', async (t) => {
   const res = await fastify.inject({ url: '/', method: 'GET', headers: { 'accept-encoding': 'gzip' } })
   t.assert.equal(zlib.gunzipSync(res.rawPayload).toString('utf8'), 'from webstream')
 })
+
+// Regression: async route handlers that produce a compressed body must follow one of the
+// patterns documented in the Fastify Routes reference — otherwise `wrap-thenable` fires a second
+// `reply.send(undefined)` while the gzip stream is still piping, silently emptying the response
+// to `Content-Length: 0`. See:
+//   https://fastify.dev/docs/latest/Reference/Routes/#promise-resolution
+//
+// These tests exercise both documented-correct patterns against the compress onSend stream path
+// so future regressions in the interaction surface here rather than as empty 200s in production.
+describe('When an async handler produces a compressed response :', async () => {
+  const bigPayload = JSON.stringify(
+    Array.from({ length: 500 }, (_, i) => ({
+      id: `id-${i}`, name: `item ${i}`, createdAt: new Date().toISOString()
+    }))
+  )
+
+  test('it should deliver the full compressed body when the handler returns the payload', async (t) => {
+    t.plan(3)
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true, threshold: 5000 })
+
+    fastify.get('/', async (_req, reply) => {
+      reply.header('content-type', 'application/json')
+      return bigPayload
+    })
+
+    const res = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+
+    t.assert.equal(res.statusCode, 200)
+    t.assert.equal(res.headers['content-encoding'], 'gzip')
+    t.assert.equal(zlib.gunzipSync(res.rawPayload).toString('utf8'), bigPayload)
+  })
+
+  test('it should deliver the full compressed body when the handler does `return reply.send(...)`', async (t) => {
+    t.plan(3)
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true, threshold: 5000 })
+
+    fastify.get('/', async (_req, reply) => {
+      reply.header('content-type', 'application/json')
+      return reply.send(bigPayload)
+    })
+
+    const res = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+
+    t.assert.equal(res.statusCode, 200)
+    t.assert.equal(res.headers['content-encoding'], 'gzip')
+    t.assert.equal(zlib.gunzipSync(res.rawPayload).toString('utf8'), bigPayload)
+  })
+})


### PR DESCRIPTION
## Summary

Document and regression-test the two async-handler patterns from the [Fastify Routes reference § Promise resolution](https://fastify.dev/docs/latest/Reference/Routes/#promise-resolution) against the `@fastify/compress` stream path.

The existing `` using `onSend` hook `` test in `routes-compress.test.js` uses a sync callback-style handler, so it never exercises Fastify's `wrap-thenable`. None of the other tests in this file do either. But the compress onSend hook's stream output (above threshold) interacts with async handlers in a way that isn't currently covered: if a user writes `async (req, reply) => { reply.send(data) }` (implicit `undefined` return), `wrap-thenable` fires a second `reply.send(undefined)` while the gzip stream is still piping — `reply.sent` is `raw.writableEnded`, which stays `false` for streams — and the response silently empties to `Content-Length: 0`.

Per the Fastify Routes reference, the correct async patterns are:

> If using async/await or promises but responding with `reply.send`:
> - Do `return reply` / `await reply`.
> - Do not forget to call `reply.send`.
>
> If using async/await or promises:
> - Do not use `reply.send`.
> - Do return the value to send.

This PR adds two passing tests — one per documented pattern — against the compress stream path (`threshold: 5000`, 36 KB payload). They're positive regressions: future changes that break this interaction will turn these red.

No production code change. Related context: https://github.com/fastify/fastify/issues/6682 (closed — WAD per the docs).

## Test plan

- [x] `node --test test/routes-compress.test.js` → 14/14 pass on my machine (Node 24.10.0)
- [x] Removed any test asserting the known-silent-failure anti-pattern — the docs are the source of truth for \"do not do this\"; the tests cover only the sanctioned patterns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)