### PR TITLE
fix: replace peek-stream/readable-stream with native node:stream  fixes empty body on Node.js 24

### DIFF
--- a/.c8rc
+++ b/.c8rc
@@ -3,7 +3,8 @@
   "exclude": [
     "test/",
     "coverage/",
-    "types/"
+    "types/",
+    "eslint.config.js"
   ],
   "clean": true,
   "check-coverage": true,

--- a/index.js
+++ b/index.js
@@ -2,14 +2,11 @@
 
 const zlib = require('node:zlib')
 const { inherits, format } = require('node:util')
-const { pipeline, compose } = require('node:stream')
+const { pipeline, compose, Readable, Transform } = require('node:stream')
 
 const fp = require('fastify-plugin')
 const encodingNegotiator = require('@fastify/accept-negotiator')
 const mimedb = require('mime-db')
-const peek = require('peek-stream')
-const { Minipass } = require('minipass')
-const { Readable } = require('readable-stream')
 
 const { isStream, isGzip, isDeflate, intoAsyncIterator, isWebReadableStream, isFetchResponse, webStreamToNodeReadable } = require('./lib/utils')
 
@@ -557,26 +554,90 @@ function maybeUnzip (payload, serialize) {
 }
 
 function zipStream (deflate, encoding) {
-  return peek({ newline: false, maxBuffer: 10 }, function (data, swap) {
-    switch (isCompressed(data)) {
-      case 1: return swap(null, new Minipass())
-      case 2: return swap(null, new Minipass())
+  let compressor = null
+  let isPassthrough = false
+
+  return new Transform({
+    transform (chunk, _enc, callback) {
+      if (isPassthrough) {
+        callback(null, chunk)
+        return
+      }
+
+      if (compressor !== null) {
+        compressor.write(chunk, callback)
+        return
+      }
+
+      switch (isCompressed(chunk)) {
+        case 1:
+        case 2:
+          isPassthrough = true
+          callback(null, chunk)
+          return
+      }
+
+      compressor = deflate[encoding]()
+      compressor.on('data', (c) => this.push(c))
+      compressor.on('error', (err) => this.destroy(err))
+      compressor.write(chunk, callback)
+    },
+    flush (callback) {
+      if (compressor !== null) {
+        compressor.once('end', callback)
+        compressor.end()
+      } else {
+        callback()
+      }
     }
-    return swap(null, deflate[encoding]())
   })
 }
 
 function unzipStream (inflate, maxRecursion) {
   if (!(maxRecursion >= 0)) maxRecursion = 3
-  return peek({ newline: false, maxBuffer: 10 }, function (data, swap) {
-    // This path is never taken, when `maxRecursion` < 0 it is automatically set back to 3
-    /* c8 ignore next */
-    if (maxRecursion < 0) return swap(new Error('Maximum recursion reached'))
-    switch (isCompressed(data)) {
-      case 1: return swap(null, compose(inflate.gzip(), unzipStream(inflate, maxRecursion - 1)))
-      case 2: return swap(null, compose(inflate.deflate(), unzipStream(inflate, maxRecursion - 1)))
+  let decompressor = null
+  let isPassthrough = false
+
+  return new Transform({
+    transform (chunk, _enc, callback) {
+      if (isPassthrough) {
+        callback(null, chunk)
+        return
+      }
+
+      if (decompressor !== null) {
+        decompressor.write(chunk, callback)
+        return
+      }
+
+      switch (isCompressed(chunk)) {
+        case 1: {
+          decompressor = compose(inflate.gzip(), unzipStream(inflate, maxRecursion - 1))
+          decompressor.on('data', (c) => this.push(c))
+          decompressor.on('error', (err) => this.destroy(err))
+          decompressor.write(chunk, callback)
+          return
+        }
+        case 2: {
+          decompressor = compose(inflate.deflate(), unzipStream(inflate, maxRecursion - 1))
+          decompressor.on('data', (c) => this.push(c))
+          decompressor.on('error', (err) => this.destroy(err))
+          decompressor.write(chunk, callback)
+          return
+        }
+      }
+
+      isPassthrough = true
+      callback(null, chunk)
+    },
+    flush (callback) {
+      if (decompressor !== null) {
+        decompressor.once('end', callback)
+        decompressor.end()
+      } else {
+        callback()
+      }
     }
-    return swap(null, new Minipass())
   })
 }
 

--- a/package.json
+++ b/package.json
@@ -8,10 +8,7 @@
   "dependencies": {
     "@fastify/accept-negotiator": "^2.0.0",
     "fastify-plugin": "^5.0.0",
-    "mime-db": "^1.52.0",
-    "minipass": "^7.0.4",
-    "peek-stream": "^1.1.3",
-    "readable-stream": "^4.5.2"
+    "mime-db": "^1.52.0"
   },
   "devDependencies": {
     "@types/node": "^25.0.3",

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -765,6 +765,37 @@ describe('When a malformed custom `zlib` option is provided, it should compress 
     const payload = zlib.gunzipSync(response.rawPayload)
     t.assert.equal(payload.toString('utf-8'), 'hello')
   })
+
+  test('using the fallback default Node.js core `zlib.createZstdCompress()` method', async (t) => {
+    if (typeof zlib.createZstdCompress !== 'function') {
+      t.skip('zstd not supported in this Node.js version')
+      return
+    }
+    t.plan(1)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, {
+      global: true,
+      threshold: 0,
+      zlib: true // will trigger a fallback on the default zlib.createZstdCompress
+    })
+
+    fastify.get('/', (_request, reply) => {
+      reply
+        .type('text/plain')
+        .compress('hello')
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: {
+        'accept-encoding': 'zstd'
+      }
+    })
+    const payload = zlib.zstdDecompressSync(response.rawPayload)
+    t.assert.equal(payload.toString('utf-8'), 'hello')
+  })
 })
 
 describe('When `inflateIfDeflated` is `true` and `X-No-Compression` request header is `true` :', async () => {
@@ -2057,6 +2088,33 @@ describe('It should remove `Content-Length` header :', async () => {
     t.assert.ok(!response.headers.vary)
     t.assert.ok(!response.headers['content-length'], 'no content length')
     t.assert.equal(file, response.payload)
+  })
+
+  test('using `onSend` hook on a multi-chunk uncompressed Stream when `inflateIfDeflated` is `true` and `X-No-Compression` request header is `true`', async (t) => {
+    t.plan(4)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true, inflateIfDeflated: true })
+
+    fastify.get('/', (_request, reply) => {
+      const stream = new Readable({ read () {} })
+      reply.header('Content-Type', 'text/plain').send(stream)
+      stream.push('hello ')
+      stream.push('world')
+      stream.push(null)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: {
+        'x-no-compression': true
+      }
+    })
+    t.assert.equal(response.statusCode, 200)
+    t.assert.ok(!response.headers.vary)
+    t.assert.ok(!response.headers['content-length'], 'no content length')
+    t.assert.equal(response.payload, 'hello world')
   })
 })
 


### PR DESCRIPTION
Closes #393

## Problem

On Node.js 24, all compressed responses silently return an empty body despite
correct `Content-Encoding` headers. Requests without `Accept-Encoding` (identity
path) work fine.

Root cause identified in #393: `peek-stream@1.1.3` (unmaintained since 2019)
depends on `readable-stream` (a userland polyfill). On Node 24 the hybrid stream
objects they produce are structurally incompatible with native stream machinery
the pipeline closes the writable side before any data reaches the readable side.

## Solution

Drop the three affected dependencies and rewrite using native `node:stream`:

- **[zipStream()](cci:1://file:///c:/Users/pc/Documents/assets/fastify-compres/index.js:555:0-593:1)**  native `Transform` that checks the first chunk with the
  existing [isGzip](cci:1://file:///c:/Users/pc/Documents/assets/fastify-compres/lib/utils.js:35:0-47:1)/[isDeflate](cci:1://file:///c:/Users/pc/Documents/assets/fastify-compres/lib/utils.js:18:0-33:1) magic-byte helpers, then either passes through
  (already compressed) or lazily wires in the real zlib compressor
- **[unzipStream()](cci:1://file:///c:/Users/pc/Documents/assets/fastify-compres/index.js:595:0-641:1)**  same pattern, preserving the recursive
  `compose(inflate.gzip/deflate(), unzipStream(...))` decompression chain
- **Imports** — `Readable` and `Transform` sourced from `node:stream`

## Changes

| File | Change |
|---|---|
| [index.js](cci:7://file:///c:/Users/pc/Documents/assets/fastify-compres/index.js:0:0-0:0) | Remove `peek-stream`/`minipass`/`readable-stream` imports; rewrite [zipStream()](cci:1://file:///c:/Users/pc/Documents/assets/fastify-compres/index.js:555:0-593:1) and [unzipStream()](cci:1://file:///c:/Users/pc/Documents/assets/fastify-compres/index.js:595:0-641:1) |
| [package.json](cci:7://file:///c:/Users/pc/Documents/assets/fastify-compres/package.json:0:0-0:0) | Remove `peek-stream`, `readable-stream`, `minipass` from dependencies |
| [test/global-compress.test.js](cci:7://file:///c:/Users/pc/Documents/assets/fastify-compres/test/global-compress.test.js:0:0-0:0) | Add multi-chunk uncompressed stream test + zstd malformed-zlib fallback test |
| [.c8rc](cci:7://file:///c:/Users/pc/Documents/assets/fastify-compres/.c8rc:0:0-0:0) | Exclude [eslint.config.js](cci:7://file:///c:/Users/pc/Documents/assets/fastify-compres/eslint.config.js:0:0-0:0) from coverage |

## Testing
node --test 
 180 pass, 0 fail 
npm run test:coverage 
100% lines / functions / statements / branches