### PR TITLE
fix(index): preserve global option fields when route options are partial

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,9 +57,10 @@ function fastifyCompress (fastify, opts, next) {
     // Manage compression options
     if (routeOptions.compress !== undefined) {
       if (typeof routeOptions.compress === 'object') {
-        const mergedCompressParams = Object.assign(
-          {}, globalCompressParams, processCompressParams(routeOptions.compress)
-        )
+        // Merge raw user options first so that route options that are *partial*
+        // do not silently overwrite globally-defined fields with `undefined`.
+        // See https://github.com/fastify/fastify-compress/issues/340
+        const mergedCompressParams = processCompressParams({ ...opts, ...routeOptions.compress })
 
         // if the current endpoint has a custom compress configuration ...
         buildRouteCompress(fastify, mergedCompressParams, routeOptions)
@@ -86,10 +87,10 @@ function fastifyCompress (fastify, opts, next) {
     // Manage decompression options
     if (routeOptions.decompress !== undefined) {
       if (typeof routeOptions.decompress === 'object') {
-        // if the current endpoint has a custom compress configuration ...
-        const mergedDecompressParams = Object.assign(
-          {}, globalDecompressParams, processDecompressParams(routeOptions.decompress)
-        )
+        // Merge raw user options first so that route options that are *partial*
+        // do not silently overwrite globally-defined fields with `undefined`.
+        // See https://github.com/fastify/fastify-compress/issues/340
+        const mergedDecompressParams = processDecompressParams({ ...opts, ...routeOptions.decompress })
 
         buildRouteDecompress(fastify, mergedDecompressParams, routeOptions)
       } else if (routeOptions.decompress === false) {

--- a/test/routes-compress.test.js
+++ b/test/routes-compress.test.js
@@ -470,3 +470,41 @@ test('reply.compress should handle Web ReadableStream', async (t) => {
   const res = await fastify.inject({ url: '/', method: 'GET', headers: { 'accept-encoding': 'gzip' } })
   t.assert.equal(zlib.gunzipSync(res.rawPayload).toString('utf8'), 'from webstream')
 })
+
+describe('When routes `compress` options are partial — issue #340 :', async () => {
+  test('it should fall back to global `onUnsupportedEncoding` when the route only sets `threshold`', async (t) => {
+    t.plan(2)
+
+    let globalUnsupportedCalled = false
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, {
+      global: true,
+      threshold: 0,
+      onUnsupportedEncoding (encoding, _req, reply) {
+        globalUnsupportedCalled = true
+        reply.code(406)
+        return `global handler saw ${encoding}`
+      }
+    })
+
+    // Route only sets `threshold` — global `onUnsupportedEncoding` must still apply.
+    fastify.get('/', {
+      compress: {
+        threshold: 0
+      }
+    }, (_req, reply) => {
+      reply.header('content-type', 'text/plain')
+      reply.send('hello world')
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'whatever' }
+    })
+
+    t.assert.equal(globalUnsupportedCalled, true)
+    t.assert.equal(response.payload, 'global handler saw whatever')
+  })
+})

--- a/test/routes-decompress.test.js
+++ b/test/routes-decompress.test.js
@@ -318,3 +318,121 @@ describe('When using the old routes `{ config: decompress }` option :', async ()
     }
   })
 })
+
+describe('When routes `decompress` options are partial — issue #340 :', async () => {
+  test('it should fall back to global `onInvalidRequestPayload` when the route only sets `onUnsupportedRequestEncoding`', async (t) => {
+    t.plan(2)
+
+    let globalInvalidCalled = false
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, {
+      global: true,
+      onInvalidRequestPayload (encoding, _request, error) {
+        globalInvalidCalled = true
+        return {
+          statusCode: 400,
+          code: 'GLOBAL_INVALID',
+          error: 'Bad Request',
+          message: `global handler saw ${encoding} ${error.message}`
+        }
+      },
+      onUnsupportedRequestEncoding (encoding) {
+        return {
+          statusCode: 415,
+          code: 'GLOBAL_UNSUPPORTED',
+          error: 'Unsupported Media Type',
+          message: `global unsupported ${encoding}`
+        }
+      }
+    })
+
+    // Route only sets `onUnsupportedRequestEncoding`. The global
+    // `onInvalidRequestPayload` should still apply for this route — instead
+    // the bug overwrites the global hook with `undefined`.
+    fastify.post('/', {
+      decompress: {
+        onUnsupportedRequestEncoding (encoding) {
+          return {
+            statusCode: 415,
+            code: 'ROUTE_UNSUPPORTED',
+            error: 'Unsupported Media Type',
+            message: `route unsupported ${encoding}`
+          }
+        }
+      }
+    }, (request, reply) => {
+      reply.send(request.body.name)
+    })
+
+    // Send a gzip body but advertise deflate -> triggers onInvalidRequestPayload
+    const response = await fastify.inject({
+      url: '/',
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-encoding': 'deflate'
+      },
+      payload: createPayload(zlib.createGzip)
+    })
+
+    t.assert.equal(globalInvalidCalled, true)
+    t.assert.equal(response.json().code, 'GLOBAL_INVALID')
+  })
+
+  test('it should fall back to global `onUnsupportedRequestEncoding` when the route only sets `onInvalidRequestPayload`', async (t) => {
+    t.plan(2)
+
+    let globalUnsupportedCalled = false
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, {
+      global: true,
+      onUnsupportedRequestEncoding (encoding) {
+        globalUnsupportedCalled = true
+        return {
+          statusCode: 415,
+          code: 'GLOBAL_UNSUPPORTED',
+          error: 'Unsupported Media Type',
+          message: `global unsupported ${encoding}`
+        }
+      },
+      onInvalidRequestPayload (encoding, _req, error) {
+        return {
+          statusCode: 400,
+          code: 'GLOBAL_INVALID',
+          error: 'Bad Request',
+          message: `global invalid ${encoding} ${error.message}`
+        }
+      }
+    })
+
+    fastify.post('/', {
+      decompress: {
+        onInvalidRequestPayload (encoding, _req, error) {
+          return {
+            statusCode: 400,
+            code: 'ROUTE_INVALID',
+            error: 'Bad Request',
+            message: `route invalid ${encoding} ${error.message}`
+          }
+        }
+      }
+    }, (request, reply) => {
+      reply.send(request.body.name)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-encoding': 'whatever'
+      },
+      payload: createPayload(zlib.createDeflate)
+    })
+
+    t.assert.equal(globalUnsupportedCalled, true)
+    t.assert.equal(response.json().code, 'GLOBAL_UNSUPPORTED')
+  })
+})


### PR DESCRIPTION
Calling `Object.assign({}, global, processCompressParams(partialRoute))` copies undefined values from the post-processed route object onto the global params, silently nulling out fields like `onInvalidRequestPayload`, `onUnsupportedRequestEncoding`, and `onUnsupportedEncoding` whenever the route configures only one of them.

Fix the merge order: combine the raw user opts with the raw route opts first, then pass the result through `processCompressParams` / `processDecompressParams` once so each derived field is computed from a coherent input rather than shallow-merged from already-processed objects.

Adds unit tests covering both decompress hook fallbacks and the compress `onUnsupportedEncoding` fallback.

Closes https://github.com/fastify/fastify-compress/issues/340

<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
