### PR TITLE
fix: skip compression for 206 and Content-Range responses

### DIFF
--- a/index.js
+++ b/index.js
@@ -258,6 +258,9 @@ function buildRouteCompress (_fastify, params, routeOptions, decorateOnly) {
     const noCompress =
       // don't compress on x-no-compression header
       (req.headers['x-no-compression'] !== undefined) ||
+      // don't compress partial content: Content-Range describes unencoded byte offsets
+      (reply.statusCode === 206) ||
+      (reply.getHeader('Content-Range') !== undefined) ||
       // don't compress if not one of the indicated compressible types
       (shouldCompress(reply.getHeader('Content-Type') || 'application/json', params.compressibleTypes) === false) ||
       // don't compress on missing or identity `accept-encoding` header

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -3548,3 +3548,56 @@ test('It should demonstrate globalDecompression controls decompression independe
   t.assert.equal(response.statusCode, 400)
   t.assert.ok(response.body.includes('Content-Length') || response.body.includes('Bad Request'))
 })
+
+describe('Range Responses', () => {
+  test('it should not compress 206 Partial Content responses', async (t) => {
+    t.plan(4)
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { threshold: 0 })
+
+    fastify.get('/partial', (request, reply) => {
+      reply
+        .status(206)
+        .header('Content-Type', 'text/plain')
+        .header('Content-Range', 'bytes 0-4/12')
+        .header('Content-Length', '5')
+        .send('hello')
+    })
+
+    const response = await fastify.inject({
+      url: '/partial',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+
+    t.assert.equal(response.statusCode, 206)
+    t.assert.equal(response.headers['content-encoding'], undefined)
+    t.assert.equal(response.headers['content-range'], 'bytes 0-4/12')
+    t.assert.equal(response.body, 'hello')
+  })
+
+  test('it should not compress responses carrying a Content-Range header', async (t) => {
+    t.plan(4)
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { threshold: 0 })
+
+    fastify.get('/content-range', (request, reply) => {
+      reply
+        .header('Content-Type', 'text/plain')
+        .header('Content-Range', 'bytes 0-4/12')
+        .header('Content-Length', '5')
+        .send('hello')
+    })
+
+    const response = await fastify.inject({
+      url: '/content-range',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+
+    t.assert.equal(response.statusCode, 200)
+    t.assert.equal(response.headers['content-encoding'], undefined)
+    t.assert.equal(response.headers['content-range'], 'bytes 0-4/12')
+    t.assert.equal(response.body, 'hello')
+  })
+})


### PR DESCRIPTION
## Summary

A `206 Partial Content` response carries a `Content-Range` header whose byte offsets describe the **original, unencoded** payload. When `@fastify/compress` compresses such a response, the body shrinks but `Content-Range` still describes the pre-compression byte range — a range client stitching parts together gets corrupted data.

The same class of bug was recently fixed in `hono/compress` (honojs/hono#5023) and is tracked in `expressjs/compression` (#277).

## Changes

**`index.js`** — two new guards in the `noCompress` check:

```js
// don't compress partial content: Content-Range describes unencoded byte offsets
(reply.statusCode === 206) ||
(reply.getHeader('Content-Range') !== undefined) ||
```

**`test/global-compress.test.js`** — new `Range Responses` describe block with two tests:

1. `it should not compress 206 Partial Content responses`
2. `it should not compress responses carrying a Content-Range header`

## Test

```
npm test
# 0 failures — new tests pass, all existing tests pass
```

## Checklist

- [x] Tests added
- [x] All tests pass (`npm test` → 0 failures)