### PR TITLE
fix: keep the default response encoding stable across Node.js versions

### DIFF
--- a/index.js
+++ b/index.js
@@ -154,7 +154,10 @@ function processCompressParams (opts) {
 
   const supportedEncodings = ['br', 'gzip', 'deflate', 'identity']
   if (typeof zlib.createZstdCompress === 'function') {
-    supportedEncodings.unshift('zstd')
+    // Support zstd when the runtime provides it, but keep it below the
+    // historical encodings so the negotiated default does not change with the
+    // Node.js version (see #369). `identity` must stay last.
+    supportedEncodings.splice(supportedEncodings.indexOf('identity'), 0, 'zstd')
   }
 
   params.encodings = Array.isArray(opts.encodings)
@@ -194,7 +197,10 @@ function processDecompressParams (opts) {
 
   const supportedEncodings = ['br', 'gzip', 'deflate', 'identity']
   if (typeof zlib.createZstdCompress === 'function') {
-    supportedEncodings.unshift('zstd')
+    // Support zstd when the runtime provides it, but keep it below the
+    // historical encodings so the negotiated default does not change with the
+    // Node.js version (see #369). `identity` must stay last.
+    supportedEncodings.splice(supportedEncodings.indexOf('identity'), 0, 'zstd')
   }
 
   params.encodings = Array.isArray(opts.requestEncodings)

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -60,6 +60,27 @@ describe('When `global` is not set, it is `true` by default :', async () => {
     t.assert.equal(payload.toString('utf-8'), buf.toString())
   })
 
+  test('it should not change the default encoding to zstd just because the runtime supports it', async (t) => {
+    t.plan(1)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { threshold: 0 })
+
+    const buf = Buffer.from('hello world')
+    fastify.get('/', (_request, reply) => {
+      reply.send(buf)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: {
+        'accept-encoding': 'gzip, deflate, br, zstd'
+      }
+    })
+    t.assert.equal(response.headers['content-encoding'], 'br')
+  })
+
   test('it should compress Buffer data using deflate when `Accept-Encoding` request header is `deflate`', async (t) => {
     t.plan(1)
 


### PR DESCRIPTION
**Fixes #369**

### Regression
Since v8.1.0, the default response compression changes based on the Node.js version: under Node.js < 22.15 the default is `br`, but under Node.js ≥ 22.15 (where `zlib.createZstdCompress` exists) the same app defaults to `zstd`. Upgrading Node silently changes the wire format, which breaks consumers that don't expect/recognize `zstd`.

### Cause
`processCompressParams` / `processDecompressParams` build the supported-encodings list and then `unshift('zstd')` to the **front** whenever the runtime supports it:

```js
const supportedEncodings = ['br', 'gzip', 'deflate', 'identity']
if (typeof zlib.createZstdCompress === 'function') {
  supportedEncodings.unshift('zstd')   // zstd becomes the top server preference
}
```

`@fastify/accept-negotiator` uses this order to break ties, so a normal client sending `Accept-Encoding: gzip, deflate, br, zstd` now negotiates `zstd` instead of `br`.

### Fix
Insert `zstd` **before `identity`** rather than at the front, so `br` stays the negotiated default (matching pre-8.1.0 behavior) while `zstd` is still offered when a client explicitly prefers it. `identity` remains last. Applied to both the compress and decompress encoding lists.

### Tests
Added a test asserting that a client accepting `gzip, deflate, br, zstd` gets `br` (not `zstd`) on a zstd-capable runtime. Verified failing before the fix (`expected 'br', actual 'zstd'`) and passing after. Full unit suite: 174/174 pass, lint clean. The existing explicit-`zstd` and wildcard (`*` → gzip) tests are unaffected.
