### PR TITLE
fix: avoid unsupported handler for skipped compression

### DIFF
--- a/index.js
+++ b/index.js
@@ -264,14 +264,15 @@ function buildRouteCompress (_fastify, params, routeOptions, decorateOnly) {
       return next()
     }
 
-    let stream, encoding
+    let stream
+    const encoding = getEncodingHeader(params.encodings, req)
     const noCompress =
       // don't compress on x-no-compression header
       (req.headers['x-no-compression'] !== undefined) ||
       // don't compress if not one of the indicated compressible types
       (shouldCompress(reply.getHeader('Content-Type') || 'application/json', params.compressibleTypes) === false) ||
       // don't compress on missing or identity `accept-encoding` header
-      ((encoding = getEncodingHeader(params.encodings, req)) == null || encoding === 'identity')
+      (encoding == null || encoding === 'identity')
 
     if (encoding == null && params.onUnsupportedEncoding != null) {
       const encodingHeader = req.headers['accept-encoding']
@@ -391,14 +392,15 @@ function compress (params) {
       return
     }
 
-    let stream, encoding
+    let stream
+    const encoding = getEncodingHeader(params.encodings, this.request)
     const noCompress =
       // don't compress on x-no-compression header
       (this.request.headers['x-no-compression'] !== undefined) ||
       // don't compress if not one of the indicated compressible types
       (shouldCompress(this.getHeader('Content-Type') || 'application/json', params.compressibleTypes) === false) ||
       // don't compress on missing or identity `accept-encoding` header
-      ((encoding = getEncodingHeader(params.encodings, this.request)) == null || encoding === 'identity')
+      (encoding == null || encoding === 'identity')
 
     if (encoding == null && params.onUnsupportedEncoding != null) {
       const encodingHeader = this.request.headers['accept-encoding']

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -2401,6 +2401,41 @@ describe('It should add hooks correctly: ', async () => {
 })
 
 describe('When `Accept-Encoding` request header values are not supported and `onUnsupportedEncoding` is defined :', async () => {
+  test('it should not call `onUnsupportedEncoding()` when supported encoding is skipped by x-no-compression', async (t) => {
+    t.plan(4)
+
+    let unsupportedCalls = 0
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, {
+      global: true,
+      onUnsupportedEncoding: (encoding, _request, reply) => {
+        unsupportedCalls++
+        reply.code(406)
+        return JSON.stringify({ hello: encoding })
+      }
+    })
+
+    fastify.get('/', (_request, reply) => {
+      reply
+        .header('Content-Type', 'text/plain')
+        .send('hello')
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: {
+        'accept-encoding': 'gzip',
+        'x-no-compression': true
+      }
+    })
+
+    t.assert.equal(response.statusCode, 200)
+    t.assert.equal(response.payload, 'hello')
+    t.assert.ok(!response.headers['content-encoding'])
+    t.assert.equal(unsupportedCalls, 0)
+  })
+
   test('it should call the defined `onUnsupportedEncoding()` method', async (t) => {
     t.plan(2)
 
@@ -3216,6 +3251,40 @@ describe('It should uncompress data when `Accept-Encoding` request header is mis
 })
 
 describe('When `onUnsupportedEncoding` is set and the `Accept-Encoding` request header value is an unsupported encoding', async () => {
+  test('it should not call `onUnsupportedEncoding()` when supported encoding is skipped by content type', async (t) => {
+    t.plan(4)
+
+    let unsupportedCalls = 0
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, {
+      global: true,
+      onUnsupportedEncoding: (encoding, _request, reply) => {
+        unsupportedCalls++
+        reply.code(406)
+        return JSON.stringify({ hello: encoding })
+      }
+    })
+
+    fastify.get('/', (_request, reply) => {
+      reply
+        .type('image/png')
+        .compress(Buffer.from('hello'))
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: {
+        'accept-encoding': 'gzip'
+      }
+    })
+
+    t.assert.equal(response.statusCode, 200)
+    t.assert.equal(response.rawPayload.toString(), 'hello')
+    t.assert.ok(!response.headers['content-encoding'])
+    t.assert.equal(unsupportedCalls, 0)
+  })
+
   test('it should call the defined `onUnsupportedEncoding()` method', async (t) => {
     t.plan(3)
 


### PR DESCRIPTION
Fixes #305.

## Summary
- negotiate `Accept-Encoding` before evaluating no-compression conditions
- avoid calling `onUnsupportedEncoding` when a supported encoding is skipped by `x-no-compression` or a non-compressible content type
- add regression coverage for both the onSend hook and `reply.compress()` paths

## Checks
- `npm.cmd run lint`
- `npm.cmd test`