### PR TITLE
fix: merge partial route decompress options

### DIFF
--- a/index.js
+++ b/index.js
@@ -77,9 +77,7 @@ function fastifyCompress (fastify, opts, next) {
     if (routeOptions.decompress !== undefined) {
       if (typeof routeOptions.decompress === 'object') {
         // if the current endpoint has a custom compress configuration ...
-        const mergedDecompressParams = Object.assign(
-          {}, globalDecompressParams, processDecompressParams(routeOptions.decompress)
-        )
+        const mergedDecompressParams = processDecompressParams(routeOptions.decompress, globalDecompressParams)
 
         buildRouteDecompress(fastify, mergedDecompressParams, routeOptions)
       } else if (routeOptions.decompress === false) {
@@ -166,30 +164,37 @@ function processCompressParams (opts) {
   return params
 }
 
-function processDecompressParams (opts) {
+function processDecompressParams (opts, defaults) {
   /* c8 ignore next 3 */
   if (!opts) {
     return
   }
 
-  const customZlib = opts.zlib || zlib
+  const customZlib = opts.zlib || {}
+  const defaultDecompressStream = defaults?.decompressStream || {}
 
   const params = {
-    global: (typeof opts.globalDecompression === 'boolean')
+    global: typeof opts.globalDecompression === 'boolean'
       ? opts.globalDecompression
-      : (typeof opts.global === 'boolean') ? opts.global : true,
-    onUnsupportedRequestEncoding: opts.onUnsupportedRequestEncoding,
-    onInvalidRequestPayload: opts.onInvalidRequestPayload,
+      : typeof opts.global === 'boolean'
+        ? opts.global
+        : defaults?.global ?? true,
+    onUnsupportedRequestEncoding: Object.hasOwn(opts, 'onUnsupportedRequestEncoding')
+      ? opts.onUnsupportedRequestEncoding
+      : defaults?.onUnsupportedRequestEncoding,
+    onInvalidRequestPayload: Object.hasOwn(opts, 'onInvalidRequestPayload')
+      ? opts.onInvalidRequestPayload
+      : defaults?.onInvalidRequestPayload,
     decompressStream: {
-      br: customZlib.createBrotliDecompress || zlib.createBrotliDecompress,
-      gzip: customZlib.createGunzip || zlib.createGunzip,
-      deflate: customZlib.createInflate || zlib.createInflate
+      br: customZlib.createBrotliDecompress || defaultDecompressStream.br || zlib.createBrotliDecompress,
+      gzip: customZlib.createGunzip || defaultDecompressStream.gzip || zlib.createGunzip,
+      deflate: customZlib.createInflate || defaultDecompressStream.deflate || zlib.createInflate
     },
     encodings: [],
-    forceEncoding: null
+    forceEncoding: defaults?.forceEncoding ?? null
   }
-  if (typeof (customZlib.createZstdDecompress || zlib.createZstdDecompress) === 'function') {
-    params.decompressStream.zstd = customZlib.createZstdDecompress || zlib.createZstdDecompress
+  if (typeof (customZlib.createZstdDecompress || defaultDecompressStream.zstd || zlib.createZstdDecompress) === 'function') {
+    params.decompressStream.zstd = customZlib.createZstdDecompress || defaultDecompressStream.zstd || zlib.createZstdDecompress
   }
 
   const supportedEncodings = ['br', 'gzip', 'deflate', 'identity']
@@ -201,9 +206,9 @@ function processDecompressParams (opts) {
     ? supportedEncodings
       .filter(encoding => opts.requestEncodings.includes(encoding))
       .sort((a, b) => opts.requestEncodings.indexOf(a) - opts.requestEncodings.indexOf(b))
-    : supportedEncodings
+    : defaults?.encodings || supportedEncodings
 
-  if (opts.forceRequestEncoding) {
+  if (Object.hasOwn(opts, 'forceRequestEncoding') && opts.forceRequestEncoding) {
     params.forceEncoding = opts.forceRequestEncoding
 
     if (params.encodings.includes(opts.forceRequestEncoding)) {

--- a/test/routes-decompress.test.js
+++ b/test/routes-decompress.test.js
@@ -138,6 +138,71 @@ describe('When using routes `decompress` settings :', async () => {
     equal(response.body, '@fastify/compress')
   })
 
+  test('it should merge partial route options with global decompression options', async (t) => {
+    t.plan(4)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, {
+      onInvalidRequestPayload (encoding, _request, error) {
+        return {
+          statusCode: 400,
+          code: 'GLOBAL_INVALID',
+          error: 'Bad Request',
+          message: `Global invalid payload handler for ${encoding}: ${error.message}.`
+        }
+      },
+      onUnsupportedRequestEncoding (encoding) {
+        return {
+          statusCode: 415,
+          code: 'GLOBAL_UNSUPPORTED',
+          error: 'Unsupported Media Type',
+          message: `Global unsupported encoding handler for ${encoding}.`
+        }
+      }
+    })
+
+    fastify.post('/custom', {
+      decompress: {
+        onUnsupportedRequestEncoding (encoding) {
+          return {
+            statusCode: 415,
+            code: 'ROUTE_UNSUPPORTED',
+            error: 'Unsupported Media Type',
+            message: `Route unsupported encoding handler for ${encoding}.`
+          }
+        }
+      }
+    }, (request, reply) => {
+      reply.send(request.body.name)
+    })
+
+    const invalidPayloadResponse = await fastify.inject({
+      url: '/custom',
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-encoding': 'deflate'
+      },
+      payload: createPayload(zlib.createGzip)
+    })
+
+    t.assert.equal(invalidPayloadResponse.statusCode, 400)
+    t.assert.equal(invalidPayloadResponse.json().code, 'GLOBAL_INVALID')
+
+    const unsupportedEncodingResponse = await fastify.inject({
+      url: '/custom',
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-encoding': 'whatever'
+      },
+      payload: createPayload(zlib.createDeflate)
+    })
+
+    t.assert.equal(unsupportedEncodingResponse.statusCode, 415)
+    t.assert.equal(unsupportedEncodingResponse.json().code, 'ROUTE_UNSUPPORTED')
+  })
+
   test('it should not decompress data when route `decompress` option is set to `false`', async (t) => {
     t.plan(6)
     const equal = t.assert.equal


### PR DESCRIPTION
## Summary
- merge partial route-level `decompress` options with plugin-level decompression defaults
- preserve global request decompression callbacks when a route only overrides one callback
- add a regression test for route/global callback precedence

Fixes #340

## Validation
- `npm run test:unit -- test/routes-decompress.test.js`
- `npm test`
- `npm run lint`