### PR TITLE
docs: fix broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,9 +396,8 @@ await fastify.register(
 
 ## Acknowledgments
 
-Past sponsors:
-
-- [LetzDoIt](http://www.letzdoitapp.com/)
+Past sp
+- LetzDoIt
 
 ## License
 


### PR DESCRIPTION
Fixes 404s, 3xx redirections, and missing fragments in the documentation. Part of general link cleanup being tracked in https://github.com/fastify/accept-negotiator/pull/71