### PR TITLE
fix: suppress native pipeline premature close errors in onEnd

### DIFF
--- a/index.js
+++ b/index.js
@@ -462,8 +462,12 @@ function onEnd (err) {
   // Client disconnection during streaming is expected and handled by Fastify.
   // Do not log "premature close" errors at error level since they are not
   // actual errors - they occur when clients disconnect mid-response.
+  // Node's native stream.pipeline emits ERR_STREAM_PREMATURE_CLOSE with the
+  // message 'Premature close', while the legacy pump/end-of-stream packages
+  // emit 'premature close' without a code, so both variants are checked.
   // See: https://github.com/fastify/fastify-compress/issues/382
-  if (err && err.message !== 'premature close') {
+  // See: https://github.com/fastify/fastify-compress/issues/410
+  if (err && err.code !== 'ERR_STREAM_PREMATURE_CLOSE' && err.message !== 'premature close') {
     this.log.error(err)
   }
 }

--- a/test/regression/issue-382.test.js
+++ b/test/regression/issue-382.test.js
@@ -15,7 +15,7 @@ test('should not log "premature close" errors on client disconnect (global compr
       level: 'error',
       stream: new Writable({
         write (chunk, encoding, callback) {
-          if (chunk.toString().includes('premature close')) {
+          if (/premature close/i.test(chunk.toString())) {
             prematureCloseCount++
           }
           callback()
@@ -86,7 +86,7 @@ test('should not log "premature close" errors on client disconnect (reply.compre
       level: 'error',
       stream: new Writable({
         write (chunk, encoding, callback) {
-          if (chunk.toString().includes('premature close')) {
+          if (/premature close/i.test(chunk.toString())) {
             prematureCloseCount++
           }
           callback()
@@ -157,7 +157,7 @@ test('should still log actual errors (not premature close)', async (t) => {
       stream: new Writable({
         write (chunk, encoding, callback) {
           const msg = chunk.toString()
-          if (msg.includes('premature close')) {
+          if (/premature close/i.test(msg)) {
             // Ignore premature close errors
           } else {
             errors.push(msg)

--- a/test/regression/issue-410.test.js
+++ b/test/regression/issue-410.test.js
@@ -1,0 +1,163 @@
+'use strict'
+
+const { test } = require('node:test')
+const { setTimeout: sleep } = require('node:timers/promises')
+const net = require('node:net')
+const { Writable } = require('node:stream')
+const Fastify = require('fastify')
+const fastifyCompress = require('../..')
+
+// Node's native stream.pipeline emits ERR_STREAM_PREMATURE_CLOSE whose message
+// is 'Premature close' (capital P), unlike the legacy pump/end-of-stream
+// message 'premature close'. The onEnd guard must suppress both variants.
+// See: https://github.com/fastify/fastify-compress/issues/410
+
+function buildFastify (onErrorLog) {
+  return Fastify({
+    logger: {
+      level: 'error',
+      stream: new Writable({
+        write (chunk, encoding, callback) {
+          onErrorLog(chunk.toString())
+          callback()
+        }
+      })
+    }
+  })
+}
+
+function streamRoute (reply, ReadableCtor) {
+  let chunks = 0
+  const stream = new ReadableCtor({
+    read () {
+      if (chunks >= 20) {
+        this.push(null)
+        return
+      }
+      setTimeout(() => {
+        this.push(JSON.stringify({ id: chunks, data: 'x'.repeat(1000) }) + '\n')
+        chunks++
+      }, 50)
+    }
+  })
+  reply.type('text/plain')
+  return stream
+}
+
+async function abortClients (port) {
+  // Simulate clients that disconnect before the full response is sent
+  for (let i = 0; i < 10; i++) {
+    await new Promise((_resolve) => {
+      const sock = net.connect(port, '127.0.0.1', () => {
+        sock.write('GET /stream HTTP/1.1\r\nHost: localhost\r\nAccept-Encoding: gzip\r\n\r\n')
+        // Disconnect after receiving partial response (100ms)
+        setTimeout(() => {
+          sock.destroy()
+          _resolve()
+        }, 100)
+      })
+      sock.on('error', () => _resolve())
+    })
+  }
+}
+
+test('should not log native pipeline "Premature close" (ERR_STREAM_PREMATURE_CLOSE) on client disconnect (global compression)', async (t) => {
+  let prematureCloseCount = 0
+
+  const fastify = buildFastify((msg) => {
+    if (/premature close/i.test(msg)) {
+      prematureCloseCount++
+    }
+  })
+
+  await fastify.register(fastifyCompress, {
+    global: true,
+    encodings: ['gzip'],
+    threshold: 1024
+  })
+
+  fastify.get('/stream', async (_request, reply) => {
+    return streamRoute(reply, require('node:stream').Readable)
+  })
+
+  await fastify.listen({ port: 0 })
+  const port = fastify.server.address().port
+
+  await abortClients(port)
+
+  // Allow pending callbacks to fire
+  await sleep(2000)
+  await fastify.close()
+
+  t.assert.equal(
+    prematureCloseCount,
+    0,
+    `Expected no premature close errors (any casing), but got ${prematureCloseCount} errors from 10 client disconnects`
+  )
+})
+
+test('should not log native pipeline "Premature close" (ERR_STREAM_PREMATURE_CLOSE) on client disconnect (reply.compress path)', async (t) => {
+  let prematureCloseCount = 0
+
+  const fastify = buildFastify((msg) => {
+    if (/premature close/i.test(msg)) {
+      prematureCloseCount++
+    }
+  })
+
+  await fastify.register(fastifyCompress, {
+    global: false,
+    encodings: ['gzip']
+  })
+
+  fastify.get('/stream', async (_request, reply) => {
+    return reply.compress(streamRoute(reply, require('node:stream').Readable))
+  })
+
+  await fastify.listen({ port: 0 })
+  const port = fastify.server.address().port
+
+  await abortClients(port)
+
+  // Allow pending callbacks to fire
+  await sleep(2000)
+  await fastify.close()
+
+  t.assert.equal(
+    prematureCloseCount,
+    0,
+    `Expected no premature close errors (any casing), but got ${prematureCloseCount} errors from 10 client disconnects`
+  )
+})
+
+test('should still log errors that are not premature close', async (t) => {
+  const errors = []
+
+  const fastify = buildFastify((msg) => {
+    if (!/premature close/i.test(msg)) {
+      errors.push(msg)
+    }
+  })
+
+  await fastify.register(fastifyCompress, {
+    global: true,
+    encodings: ['gzip']
+  })
+
+  fastify.get('/error', async () => {
+    throw new Error('Test error')
+  })
+
+  await fastify.inject({
+    method: 'GET',
+    url: '/error',
+    headers: { 'accept-encoding': 'gzip' }
+  })
+
+  await sleep(500)
+
+  t.assert.ok(
+    errors.length > 0,
+    'Expected actual errors to still be logged'
+  )
+})


### PR DESCRIPTION
## Checklist
- [x] run `npm run test` and `npm run benchmark`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Code of conduct](https://github.com/fastify/fastify/blob/main/CODE_OF_CONDUCT.md)

#382 added a guard in `onEnd` so client disconnects mid-response stop logging at error level, comparing `err.message` against `'premature close'` (lowercase) — the message produced by the legacy `pump`/`end-of-stream` packages. But `onEnd` is the callback of Node's **native** `stream.pipeline`, which emits `ERR_STREAM_PREMATURE_CLOSE` with the message `'Premature close'` (capital P). The case-sensitive comparison never matched, so every client abort during a compressed streaming response still logged at error level.

This PR matches on the error **code** `ERR_STREAM_PREMATURE_CLOSE`, which is stable across Node.js versions and message-wording changes, while keeping the legacy lowercase message check for streams routed through `pump`/`end-of-stream` (which set no `code`).

The existing `issue-382` regression test matched the lowercase message only, so it could not detect the native variant; it now matches any casing. A new `issue-410` regression test covers both the global-compression and `reply.compress` paths (fails with 10/10 aborts logged before the fix) and verifies real errors are still logged.

Closes #410
