### PR TITLE
refactor: remove `peek-stream` and use `readable-stream` Transform

### DIFF
--- a/.c8rc
+++ b/.c8rc
@@ -1,10 +1,6 @@
 {
   "all": true,
-  "exclude": [
-    "test/",
-    "coverage/",
-    "types/"
-  ],
+  "exclude": ["test/", "coverage/", "types/", "eslint.config.js"],
   "clean": true,
   "check-coverage": true,
   "branches": 100,

--- a/index.js
+++ b/index.js
@@ -2,12 +2,11 @@
 
 const zlib = require('node:zlib')
 const { inherits, format } = require('node:util')
-const { pipeline, compose } = require('node:stream')
+const { pipeline, compose, Duplex } = require('node:stream')
 
 const fp = require('fastify-plugin')
 const encodingNegotiator = require('@fastify/accept-negotiator')
 const mimedb = require('mime-db')
-const peek = require('peek-stream')
 const { Minipass } = require('minipass')
 const { Readable } = require('readable-stream')
 
@@ -553,8 +552,56 @@ function maybeUnzip (payload, serialize) {
   return Readable.from(intoAsyncIterator(result))
 }
 
+function createPeekStream (maxBuffer, onpeek) {
+  let buf = Buffer.alloc(0)
+  let dest = null
+
+  return new Duplex({
+    write (chunk, encoding, cb) {
+      if (dest) {
+        return dest.write(chunk, encoding, cb)
+      }
+
+      buf = Buffer.concat([buf, chunk])
+
+      if (buf.length < maxBuffer) return cb()
+
+      onpeek(buf, (err, stream) => {
+        if (err) return cb(err)
+        dest = stream
+        dest.on('data', (d) => this.push(d))
+        dest.on('end', () => this.push(null))
+        dest.write(buf, cb)
+        buf = null
+      })
+    },
+
+    final (cb) {
+      if (dest) {
+        dest.end(cb)
+        return
+      }
+
+      onpeek(buf, (err, stream) => {
+        if (err) return cb(err)
+        dest = stream
+        dest.on('data', (d) => this.push(d))
+        dest.on('end', () => { this.push(null); cb() })
+        if (buf && buf.length > 0) {
+          dest.end(buf)
+        } else {
+          dest.end()
+        }
+        buf = null
+      })
+    },
+
+    read () {}
+  })
+}
+
 function zipStream (deflate, encoding) {
-  return peek({ newline: false, maxBuffer: 10 }, function (data, swap) {
+  return createPeekStream(10, function (data, swap) {
     switch (isCompressed(data)) {
       case 1: return swap(null, new Minipass())
       case 2: return swap(null, new Minipass())
@@ -565,7 +612,7 @@ function zipStream (deflate, encoding) {
 
 function unzipStream (inflate, maxRecursion) {
   if (!(maxRecursion >= 0)) maxRecursion = 3
-  return peek({ newline: false, maxBuffer: 10 }, function (data, swap) {
+  return createPeekStream(10, function (data, swap) {
     // This path is never taken, when `maxRecursion` < 0 it is automatically set back to 3
     /* c8 ignore next */
     if (maxRecursion < 0) return swap(new Error('Maximum recursion reached'))

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 const zlib = require('node:zlib')
 const { inherits, format } = require('node:util')
-const { pipeline, compose, Duplex } = require('node:stream')
+const { pipeline, compose } = require('node:stream')
 
 const fp = require('fastify-plugin')
 const encodingNegotiator = require('@fastify/accept-negotiator')
@@ -10,7 +10,7 @@ const mimedb = require('mime-db')
 const { Minipass } = require('minipass')
 const { Readable } = require('readable-stream')
 
-const { isStream, isGzip, isDeflate, intoAsyncIterator, isWebReadableStream, isFetchResponse, webStreamToNodeReadable } = require('./lib/utils')
+const { isStream, isGzip, isDeflate, intoAsyncIterator, isWebReadableStream, isFetchResponse, webStreamToNodeReadable, createLazyTransform } = require('./lib/utils')
 
 const InvalidRequestEncodingError = createError('FST_CP_ERR_INVALID_CONTENT_ENCODING', 'Unsupported Content-Encoding: %s', 415)
 const InvalidRequestCompressedPayloadError = createError('FST_CP_ERR_INVALID_CONTENT', 'Could not decompress the request payload using the provided encoding', 400)
@@ -552,75 +552,27 @@ function maybeUnzip (payload, serialize) {
   return Readable.from(intoAsyncIterator(result))
 }
 
-function createPeekStream (maxBuffer, onpeek) {
-  let buf = Buffer.alloc(0)
-  let dest = null
-
-  return new Duplex({
-    write (chunk, encoding, cb) {
-      if (dest) {
-        return dest.write(chunk, encoding, cb)
-      }
-
-      buf = Buffer.concat([buf, chunk])
-
-      if (buf.length < maxBuffer) return cb()
-
-      onpeek(buf, (err, stream) => {
-        if (err) return cb(err)
-        dest = stream
-        dest.on('data', (d) => this.push(d))
-        dest.on('end', () => this.push(null))
-        dest.write(buf, cb)
-        buf = null
-      })
-    },
-
-    final (cb) {
-      if (dest) {
-        dest.end(cb)
-        return
-      }
-
-      onpeek(buf, (err, stream) => {
-        if (err) return cb(err)
-        dest = stream
-        dest.on('data', (d) => this.push(d))
-        dest.on('end', () => { this.push(null); cb() })
-        if (buf && buf.length > 0) {
-          dest.end(buf)
-        } else {
-          dest.end()
-        }
-        buf = null
-      })
-    },
-
-    read () {}
-  })
-}
-
 function zipStream (deflate, encoding) {
-  return createPeekStream(10, function (data, swap) {
+  return createLazyTransform(function (data) {
     switch (isCompressed(data)) {
-      case 1: return swap(null, new Minipass())
-      case 2: return swap(null, new Minipass())
+      case 1: return new Minipass()
+      case 2: return new Minipass()
     }
-    return swap(null, deflate[encoding]())
+    return deflate[encoding]()
   })
 }
 
 function unzipStream (inflate, maxRecursion) {
   if (!(maxRecursion >= 0)) maxRecursion = 3
-  return createPeekStream(10, function (data, swap) {
+  return createLazyTransform(function (data) {
     // This path is never taken, when `maxRecursion` < 0 it is automatically set back to 3
     /* c8 ignore next */
-    if (maxRecursion < 0) return swap(new Error('Maximum recursion reached'))
+    if (maxRecursion < 0) throw new Error('Maximum recursion reached')
     switch (isCompressed(data)) {
-      case 1: return swap(null, compose(inflate.gzip(), unzipStream(inflate, maxRecursion - 1)))
-      case 2: return swap(null, compose(inflate.deflate(), unzipStream(inflate, maxRecursion - 1)))
+      case 1: return compose(inflate.gzip(), unzipStream(inflate, maxRecursion - 1))
+      case 2: return compose(inflate.deflate(), unzipStream(inflate, maxRecursion - 1))
     }
-    return swap(null, new Minipass())
+    return new Minipass()
   })
 }
 

--- a/index.js
+++ b/index.js
@@ -10,7 +10,16 @@ const mimedb = require('mime-db')
 const { Minipass } = require('minipass')
 const { Readable } = require('readable-stream')
 
-const { isStream, isGzip, isDeflate, intoAsyncIterator, isWebReadableStream, isFetchResponse, webStreamToNodeReadable, createLazyTransform } = require('./lib/utils')
+const {
+  isStream,
+  isGzip,
+  isDeflate,
+  intoAsyncIterator,
+  isWebReadableStream,
+  isFetchResponse,
+  webStreamToNodeReadable,
+  createPeekTransform
+} = require('./lib/utils')
 
 const InvalidRequestEncodingError = createError('FST_CP_ERR_INVALID_CONTENT_ENCODING', 'Unsupported Content-Encoding: %s', 415)
 const InvalidRequestCompressedPayloadError = createError('FST_CP_ERR_INVALID_CONTENT', 'Could not decompress the request payload using the provided encoding', 400)
@@ -553,7 +562,7 @@ function maybeUnzip (payload, serialize) {
 }
 
 function zipStream (deflate, encoding) {
-  return createLazyTransform(function (data) {
+  return createPeekTransform(function (data) {
     switch (isCompressed(data)) {
       case 1: return new Minipass()
       case 2: return new Minipass()
@@ -564,7 +573,7 @@ function zipStream (deflate, encoding) {
 
 function unzipStream (inflate, maxRecursion) {
   if (!(maxRecursion >= 0)) maxRecursion = 3
-  return createLazyTransform(function (data) {
+  return createPeekTransform(function (data) {
     // This path is never taken, when `maxRecursion` < 0 it is automatically set back to 3
     /* c8 ignore next */
     if (maxRecursion < 0) throw new Error('Maximum recursion reached')

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -135,10 +135,11 @@ function createPeekTransform (swapStream, peekSize = 10) {
         // flush internal buffers and end the downstream
         wireDownStream((error) => {
           if (error) {
-            callback(error)
             flushCallback = null
+            callback(error)
+          } else {
+            downstream.end()
           }
-          downstream.end()
         })
       }
     }
@@ -148,10 +149,15 @@ function createPeekTransform (swapStream, peekSize = 10) {
     _transform.push(chunk)
   }
 
+  function onError (error) {
+    _transform.destroy(error)
+  }
+
   function onEnd () {
     flushCallback && flushCallback()
     // cleanup
     downstream.off('data', onData)
+    downstream.off('error', onError)
     downstream.off('end', onEnd)
     downstream = null
     flushCallback = null
@@ -164,6 +170,7 @@ function createPeekTransform (swapStream, peekSize = 10) {
     try {
       downstream = swapStream(data.subarray(0, peekSize))
       downstream.on('data', onData)
+      downstream.on('error', onError)
       downstream.on('end', onEnd)
       downstream.write(data, callback)
       // cleanup

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,7 @@
 'use strict'
 
-const { Readable: NodeReadable, Transform } = require('node:stream')
+const { Readable: NodeReadable } = require('node:stream')
+const { Transform } = require('readable-stream')
 
 // https://datatracker.ietf.org/doc/html/rfc8878#section-3.1.1
 function isZstd (buffer) {
@@ -104,61 +105,81 @@ async function * intoAsyncIterator (payload) {
   yield payload
 }
 
-/**
- * Creates a Transform that lazily selects an inner transform by peeking
- * at the first `maxBuffer` bytes.
- *
- * @param {(data: Buffer) => import('stream').Transform} choose
- *   Called once with the peeked bytes. Must return the transform stream
- *   that all data (including the peeked bytes) will be piped through.
- * @param {number} [maxBuffer=10] - Number of bytes to peek before deciding.
- * @returns {import('stream').Transform}
- */
-function createLazyTransform (choose, maxBuffer = 10) {
-  let chunks = []
-  let chunksLength = 0
-  let dest = null
+function createPeekTransform (swapStream, peekSize = 10) {
+  const buffers = []
+  let bufferSize = 0
+  let downstream = null
+  let flushCallback = null
 
-  return new Transform({
-    transform (chunk, encoding, cb) {
-      if (dest) {
-        return dest.write(chunk, encoding, cb)
-      }
+  const _transform = new Transform({
+    transform (chunk, encoding, callback) {
+      // when downstream already selected, directly passthrough
+      if (downstream !== null) return downstream.write(chunk, encoding, callback)
 
-      chunks.push(chunk)
-      chunksLength += chunk.length
+      bufferSize += chunk.length
+      buffers.push(chunk)
 
-      if (chunksLength < maxBuffer) return cb()
+      // read more data when buffer size smaller than peeksize
+      if (bufferSize < peekSize) return callback()
 
-      const buf = Buffer.concat(chunks)
-      chunks = null
-
-      dest = choose(buf.subarray(0, maxBuffer))
-      dest.on('data', (d) => this.push(d))
-      dest.on('end', () => this.push(null))
-      dest.write(buf, cb)
+      wireDownStream(callback)
     },
-
-    flush (cb) {
-      if (!dest) {
-        const buf = Buffer.concat(chunks)
-        chunks = null
-
-        dest = choose(buf)
-        dest.on('data', (d) => this.push(d))
-        dest.on('end', () => { this.push(null); cb() })
-        if (buf.length > 0) {
-          dest.end(buf)
-        } else {
-          dest.end()
-        }
-        return
+    flush (callback) {
+      // used in "end" event to notify the transform finished flush
+      flushCallback = callback
+      if (downstream !== null) {
+        // all data should be flushed to downstream already
+        // we end the stream
+        downstream.end()
+      } else {
+        // flush internal buffers and end the downstream
+        wireDownStream(() => {
+          downstream.end()
+        })
       }
-
-      dest.on('end', cb)
-      dest.end()
     }
   })
+
+  function onData (chunk) {
+    _transform.push(chunk)
+  }
+
+  function onEnd () {
+    flushCallback && flushCallback()
+    // cleanup
+    downstream.off('data', onData)
+    downstream.off('end', onEnd)
+    downstream = null
+    flushCallback = null
+
+    _transform.push(null)
+  }
+
+  function wireDownStream (callback) {
+    const data = Buffer.concat(buffers)
+    try {
+      downstream = swapStream(data.subarray(0, peekSize))
+    } catch (error) {
+      return callback(error)
+    }
+    downstream.on('data', onData)
+    downstream.on('end', onEnd)
+    downstream.write(data, callback)
+    // cleanup
+    buffers.length = 0
+  }
+
+  return _transform
 }
 
-module.exports = { isZstd, isGzip, isDeflate, isStream, intoAsyncIterator, isWebReadableStream, isFetchResponse, webStreamToNodeReadable, createLazyTransform }
+module.exports = {
+  isZstd,
+  isGzip,
+  isDeflate,
+  isStream,
+  intoAsyncIterator,
+  isWebReadableStream,
+  isFetchResponse,
+  webStreamToNodeReadable,
+  createPeekTransform
+}

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { Readable: NodeReadable } = require('node:stream')
+const { Readable: NodeReadable, Transform } = require('node:stream')
 
 // https://datatracker.ietf.org/doc/html/rfc8878#section-3.1.1
 function isZstd (buffer) {
@@ -104,4 +104,61 @@ async function * intoAsyncIterator (payload) {
   yield payload
 }
 
-module.exports = { isZstd, isGzip, isDeflate, isStream, intoAsyncIterator, isWebReadableStream, isFetchResponse, webStreamToNodeReadable }
+/**
+ * Creates a Transform that lazily selects an inner transform by peeking
+ * at the first `maxBuffer` bytes.
+ *
+ * @param {(data: Buffer) => import('stream').Transform} choose
+ *   Called once with the peeked bytes. Must return the transform stream
+ *   that all data (including the peeked bytes) will be piped through.
+ * @param {number} [maxBuffer=10] - Number of bytes to peek before deciding.
+ * @returns {import('stream').Transform}
+ */
+function createLazyTransform (choose, maxBuffer = 10) {
+  let chunks = []
+  let chunksLength = 0
+  let dest = null
+
+  return new Transform({
+    transform (chunk, encoding, cb) {
+      if (dest) {
+        return dest.write(chunk, encoding, cb)
+      }
+
+      chunks.push(chunk)
+      chunksLength += chunk.length
+
+      if (chunksLength < maxBuffer) return cb()
+
+      const buf = Buffer.concat(chunks)
+      chunks = null
+
+      dest = choose(buf.subarray(0, maxBuffer))
+      dest.on('data', (d) => this.push(d))
+      dest.on('end', () => this.push(null))
+      dest.write(buf, cb)
+    },
+
+    flush (cb) {
+      if (!dest) {
+        const buf = Buffer.concat(chunks)
+        chunks = null
+
+        dest = choose(buf)
+        dest.on('data', (d) => this.push(d))
+        dest.on('end', () => { this.push(null); cb() })
+        if (buf.length > 0) {
+          dest.end(buf)
+        } else {
+          dest.end()
+        }
+        return
+      }
+
+      dest.on('end', cb)
+      dest.end()
+    }
+  })
+}
+
+module.exports = { isZstd, isGzip, isDeflate, isStream, intoAsyncIterator, isWebReadableStream, isFetchResponse, webStreamToNodeReadable, createLazyTransform }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -133,7 +133,11 @@ function createPeekTransform (swapStream, peekSize = 10) {
         downstream.end()
       } else {
         // flush internal buffers and end the downstream
-        wireDownStream(() => {
+        wireDownStream((error) => {
+          if (error) {
+            callback(error)
+            flushCallback = null
+          }
           downstream.end()
         })
       }
@@ -159,14 +163,14 @@ function createPeekTransform (swapStream, peekSize = 10) {
     const data = Buffer.concat(buffers)
     try {
       downstream = swapStream(data.subarray(0, peekSize))
+      downstream.on('data', onData)
+      downstream.on('end', onEnd)
+      downstream.write(data, callback)
+      // cleanup
+      buffers.length = 0
     } catch (error) {
-      return callback(error)
+      callback(error)
     }
-    downstream.on('data', onData)
-    downstream.on('end', onEnd)
-    downstream.write(data, callback)
-    // cleanup
-    buffers.length = 0
   }
 
   return _transform

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint:fix": "eslint --fix",
     "test": "npm run test:unit && npm run test:typescript",
     "test:typescript": "tstyche",
-    "test:unit": "c8 node --test",
+    "test:unit": "node --test",
     "test:coverage": "c8 node --test && c8 report --reporter=html",
     "test:unit:verbose": "npm run test:unit -- -Rspec"
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "lint:fix": "eslint --fix",
     "test": "npm run test:unit && npm run test:typescript",
     "test:typescript": "tstyche",
-    "test:unit": "node --test",
+    "test:unit": "c8 node --test",
     "test:coverage": "c8 node --test && c8 report --reporter=html",
     "test:unit:verbose": "npm run test:unit -- -Rspec"
   },

--- a/package.json
+++ b/package.json
@@ -10,7 +10,6 @@
     "fastify-plugin": "^6.0.0",
     "mime-db": "^1.52.0",
     "minipass": "^7.0.4",
-    "peek-stream": "^1.1.3",
     "readable-stream": "^4.5.2"
   },
   "devDependencies": {

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -297,7 +297,7 @@ describe('When `global` is not set, it is `true` by default :', async () => {
     const body = 'hello from web stream'
     fastify.get('/web-stream', (_request, reply) => {
       const stream = new WebReadableStream({
-        start (controller) {
+        start(controller) {
           controller.enqueue(Buffer.from(body))
           controller.close()
         }
@@ -682,6 +682,41 @@ describe('When a custom `zlib` option is provided, it should compress data :`', 
     t.assert.equal(response.headers['content-encoding'], 'gzip')
     t.assert.equal(payload.toString('utf-8'), file)
   })
+
+  test('using the custom `createZstdCompress()` method', async (t) => {
+    if (typeof zlib.createZstdCompress !== 'function') {
+      t.skip('zstd not supported in this Node.js version')
+      return
+    }
+    t.plan(4)
+
+    let usedCustom = false
+    const customZlib = { createZstdCompress: () => (usedCustom = true) && zlib.createZstdCompress() }
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true, zlib: customZlib })
+
+    fastify.get('/', (_request, reply) => {
+      reply
+        .type('text/plain')
+        .compress(createReadStream('./package.json'))
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: {
+        'accept-encoding': 'zstd'
+      }
+    })
+    t.assert.equal(usedCustom, true)
+
+    const file = readFileSync('./package.json', 'utf8')
+    const payload = zlib.zstdDecompressSync(response.rawPayload)
+    t.assert.equal(response.headers.vary, 'accept-encoding')
+    t.assert.equal(response.headers['content-encoding'], 'zstd')
+    t.assert.equal(payload.toString('utf-8'), file)
+  })
 })
 
 describe('When a malformed custom `zlib` option is provided, it should compress data :', async () => {
@@ -763,6 +798,37 @@ describe('When a malformed custom `zlib` option is provided, it should compress 
       }
     })
     const payload = zlib.gunzipSync(response.rawPayload)
+    t.assert.equal(payload.toString('utf-8'), 'hello')
+  })
+
+  test('using the fallback default Node.js core `zlib.createZstdCompress()` method', async (t) => {
+    if (typeof zlib.createZstdCompress !== 'function') {
+      t.skip('zstd not supported in this Node.js version')
+      return
+    }
+    t.plan(1)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, {
+      global: true,
+      threshold: 0,
+      zlib: true // will trigger a fallback on the default zlib.createZstdCompress
+    })
+
+    fastify.get('/', (_request, reply) => {
+      reply
+        .type('text/plain')
+        .compress('hello')
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: {
+        'accept-encoding': 'zstd'
+      }
+    })
+    const payload = zlib.zstdDecompressSync(response.rawPayload)
     t.assert.equal(payload.toString('utf-8'), 'hello')
   })
 })
@@ -1837,7 +1903,7 @@ test('It should log an existing error with stream onEnd handler', async (t) => {
 
   let actual = null
   const logger = new Writable({
-    write (chunk, _encoding, callback) {
+    write(chunk, _encoding, callback) {
       actual = JSON.parse(chunk.toString())
       callback()
     }
@@ -1856,7 +1922,7 @@ test('It should log an existing error with stream onEnd handler', async (t) => {
 
   fastify.get('/', (_request, reply) => {
     const stream = new Readable({
-      read () {
+      read() {
         this.destroy(expect)
       }
     })

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -297,7 +297,7 @@ describe('When `global` is not set, it is `true` by default :', async () => {
     const body = 'hello from web stream'
     fastify.get('/web-stream', (_request, reply) => {
       const stream = new WebReadableStream({
-        start(controller) {
+        start (controller) {
           controller.enqueue(Buffer.from(body))
           controller.close()
         }
@@ -1903,7 +1903,7 @@ test('It should log an existing error with stream onEnd handler', async (t) => {
 
   let actual = null
   const logger = new Writable({
-    write(chunk, _encoding, callback) {
+    write (chunk, _encoding, callback) {
       actual = JSON.parse(chunk.toString())
       callback()
     }
@@ -1922,7 +1922,7 @@ test('It should log an existing error with stream onEnd handler', async (t) => {
 
   fastify.get('/', (_request, reply) => {
     const stream = new Readable({
-      read() {
+      read () {
         this.destroy(expect)
       }
     })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -240,4 +240,24 @@ test('createPeekTransform', async (t) => {
 
     await t.assert.rejects(finished(transform), new Error('boom'))
   })
+
+  await t.test('error inside downstream', async (t) => {
+    t.plan(2)
+
+    const transform = createPeekTransform(function (data) {
+      return new Transform({
+        transform (chunk, encoding, callback) {
+          callback(new Error('boom'))
+        }
+      })
+    })
+
+    transform.on('data', (chunk) => { t.assert.fail('should not reach') })
+    transform.on('error', (error) => { t.assert.ok(error) })
+    transform.write('hello')
+    transform.write('world')
+    transform.end()
+
+    await t.assert.rejects(finished(transform), new Error('boom'))
+  })
 })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -224,4 +224,20 @@ test('createPeekTransform', async (t) => {
 
     t.assert.strictEqual(data, 'HELLOWORLD')
   })
+
+  await t.test('error when data size < peekSize', async (t) => {
+    t.plan(2)
+
+    const transform = createPeekTransform(function (data) {
+      throw new Error('boom')
+    }, 100)
+
+    transform.on('data', (chunk) => { t.assert.fail('should not reach') })
+    transform.on('error', (error) => { t.assert.ok(error) })
+    transform.write('hello')
+    transform.write('world')
+    transform.end()
+
+    await t.assert.rejects(finished(transform), new Error('boom'))
+  })
 })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -3,8 +3,9 @@
 const { createReadStream } = require('node:fs')
 const { Socket } = require('node:net')
 const { Duplex, PassThrough, Readable, Stream, Transform, Writable } = require('node:stream')
+const { pipeline } = require('node:stream/promises')
 const { test } = require('node:test')
-const { isStream, isZstd, isDeflate, isGzip, intoAsyncIterator } = require('../lib/utils')
+const { isStream, isZstd, isDeflate, isGzip, intoAsyncIterator, createLazyTransform } = require('../lib/utils')
 
 test('isStream() utility should be able to detect Streams', async (t) => {
   t.plan(12)
@@ -123,4 +124,124 @@ test('intoAsyncIterator() utility should handle different data', async (t) => {
   for await (const chunk of intoAsyncIterator(obj)) {
     equal(chunk, obj)
   }
+})
+
+test('createLazyTransform() should peek at first N bytes and pipe through selected stream', async (t) => {
+  const input = Buffer.from('hello world')
+  const chunks = []
+
+  const peekStream = createLazyTransform((data) => {
+    t.assert.equal(data.length, 5)
+    t.assert.equal(data.toString(), 'hello')
+    return new PassThrough()
+  }, 5)
+
+  peekStream.on('data', (chunk) => chunks.push(chunk))
+
+  await new Promise((resolve, reject) => {
+    peekStream.on('end', resolve)
+    peekStream.on('error', reject)
+    peekStream.write(input)
+    peekStream.end()
+  })
+
+  t.assert.equal(Buffer.concat(chunks).toString(), 'hello world')
+})
+
+test('createLazyTransform() should work when data arrives in small chunks', async (t) => {
+  const chunks = []
+
+  const peekStream = createLazyTransform((data) => {
+    t.assert.equal(data.length, 4)
+    t.assert.equal(data.toString(), 'abcd')
+    return new PassThrough()
+  }, 4)
+
+  peekStream.on('data', (chunk) => chunks.push(chunk))
+
+  await new Promise((resolve, reject) => {
+    peekStream.on('end', resolve)
+    peekStream.on('error', reject)
+    peekStream.write(Buffer.from('ab'))
+    peekStream.write(Buffer.from('cd'))
+    peekStream.write(Buffer.from('ef'))
+    peekStream.end()
+  })
+
+  t.assert.equal(Buffer.concat(chunks).toString(), 'abcdef')
+})
+
+test('createLazyTransform() should handle stream ending before maxBuffer is reached', async (t) => {
+  const chunks = []
+
+  const peekStream = createLazyTransform((data) => {
+    t.assert.equal(data.toString(), 'hi')
+    return new PassThrough()
+  })
+
+  peekStream.on('data', (chunk) => chunks.push(chunk))
+
+  await new Promise((resolve, reject) => {
+    peekStream.on('end', resolve)
+    peekStream.on('error', reject)
+    peekStream.write(Buffer.from('hi'))
+    peekStream.end()
+  })
+
+  t.assert.equal(Buffer.concat(chunks).toString(), 'hi')
+})
+
+test('createLazyTransform() should propagate errors from choose function', async (t) => {
+  const peekStream = createLazyTransform(() => {
+    throw new Error('test error')
+  }, 2)
+
+  await t.assert.rejects(
+    pipeline(Readable.from(Buffer.from('hello')), peekStream, new PassThrough()),
+    { message: 'test error' }
+  )
+})
+
+test('createLazyTransform() should handle empty stream', async (t) => {
+  const chunks = []
+
+  const peekStream = createLazyTransform((data) => {
+    t.assert.equal(data.length, 0)
+    return new PassThrough()
+  })
+
+  peekStream.on('data', (chunk) => chunks.push(chunk))
+
+  await new Promise((resolve, reject) => {
+    peekStream.on('end', resolve)
+    peekStream.on('error', reject)
+    peekStream.end()
+  })
+
+  t.assert.equal(Buffer.concat(chunks).length, 0)
+})
+
+test('createLazyTransform() should work with a transform stream as destination', async (t) => {
+  const chunks = []
+
+  const upper = new Transform({
+    transform (chunk, enc, cb) {
+      cb(null, chunk.toString().toUpperCase())
+    }
+  })
+
+  const peekStream = createLazyTransform(() => {
+    return upper
+  }, 3)
+
+  peekStream.on('data', (chunk) => chunks.push(chunk))
+
+  await new Promise((resolve, reject) => {
+    peekStream.on('end', resolve)
+    peekStream.on('error', reject)
+    peekStream.write(Buffer.from('hello'))
+    peekStream.end()
+  })
+
+  t.assert.equal(Buffer.concat(chunks).toString(), 'HELLO')
 })

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -3,9 +3,9 @@
 const { createReadStream } = require('node:fs')
 const { Socket } = require('node:net')
 const { Duplex, PassThrough, Readable, Stream, Transform, Writable } = require('node:stream')
-const { pipeline } = require('node:stream/promises')
+const { finished } = require('node:stream/promises')
 const { test } = require('node:test')
-const { isStream, isZstd, isDeflate, isGzip, intoAsyncIterator, createLazyTransform } = require('../lib/utils')
+const { isStream, isZstd, isDeflate, isGzip, intoAsyncIterator, createPeekTransform } = require('../lib/utils')
 
 test('isStream() utility should be able to detect Streams', async (t) => {
   t.plan(12)
@@ -126,122 +126,102 @@ test('intoAsyncIterator() utility should handle different data', async (t) => {
   }
 })
 
-test('createLazyTransform() should peek at first N bytes and pipe through selected stream', async (t) => {
-  const input = Buffer.from('hello world')
-  const chunks = []
-
-  const peekStream = createLazyTransform((data) => {
-    t.assert.equal(data.length, 5)
-    t.assert.equal(data.toString(), 'hello')
-    return new PassThrough()
-  }, 5)
-
-  peekStream.on('data', (chunk) => chunks.push(chunk))
-
-  await new Promise((resolve, reject) => {
-    peekStream.on('end', resolve)
-    peekStream.on('error', reject)
-    peekStream.write(input)
-    peekStream.end()
-  })
-
-  t.assert.equal(Buffer.concat(chunks).toString(), 'hello world')
-})
-
-test('createLazyTransform() should work when data arrives in small chunks', async (t) => {
-  const chunks = []
-
-  const peekStream = createLazyTransform((data) => {
-    t.assert.equal(data.length, 4)
-    t.assert.equal(data.toString(), 'abcd')
-    return new PassThrough()
-  }, 4)
-
-  peekStream.on('data', (chunk) => chunks.push(chunk))
-
-  await new Promise((resolve, reject) => {
-    peekStream.on('end', resolve)
-    peekStream.on('error', reject)
-    peekStream.write(Buffer.from('ab'))
-    peekStream.write(Buffer.from('cd'))
-    peekStream.write(Buffer.from('ef'))
-    peekStream.end()
-  })
-
-  t.assert.equal(Buffer.concat(chunks).toString(), 'abcdef')
-})
-
-test('createLazyTransform() should handle stream ending before maxBuffer is reached', async (t) => {
-  const chunks = []
-
-  const peekStream = createLazyTransform((data) => {
-    t.assert.equal(data.toString(), 'hi')
-    return new PassThrough()
-  })
-
-  peekStream.on('data', (chunk) => chunks.push(chunk))
-
-  await new Promise((resolve, reject) => {
-    peekStream.on('end', resolve)
-    peekStream.on('error', reject)
-    peekStream.write(Buffer.from('hi'))
-    peekStream.end()
-  })
-
-  t.assert.equal(Buffer.concat(chunks).toString(), 'hi')
-})
-
-test('createLazyTransform() should propagate errors from choose function', async (t) => {
-  const peekStream = createLazyTransform(() => {
-    throw new Error('test error')
-  }, 2)
-
-  await t.assert.rejects(
-    pipeline(Readable.from(Buffer.from('hello')), peekStream, new PassThrough()),
-    { message: 'test error' }
-  )
-})
-
-test('createLazyTransform() should handle empty stream', async (t) => {
-  const chunks = []
-
-  const peekStream = createLazyTransform((data) => {
-    t.assert.equal(data.length, 0)
-    return new PassThrough()
-  })
-
-  peekStream.on('data', (chunk) => chunks.push(chunk))
-
-  await new Promise((resolve, reject) => {
-    peekStream.on('end', resolve)
-    peekStream.on('error', reject)
-    peekStream.end()
-  })
-
-  t.assert.equal(Buffer.concat(chunks).length, 0)
-})
-
-test('createLazyTransform() should work with a transform stream as destination', async (t) => {
-  const chunks = []
-
-  const upper = new Transform({
-    transform (chunk, enc, cb) {
-      cb(null, chunk.toString().toUpperCase())
+test('createPeekTransform', async (t) => {
+  class UpperCaseTransform extends Transform {
+    _transform (chunk, encoding, callback) {
+      callback(null, chunk.toString().toUpperCase())
     }
+  }
+
+  await t.test('uppercase', async (t) => {
+    t.plan(2)
+
+    const transform = createPeekTransform(function (data) {
+      t.assert.strictEqual(data.toString(), 'hello\nworl')
+      return new UpperCaseTransform()
+    })
+
+    let data = ''
+    transform.on('data', (chunk) => { data += chunk.toString() })
+    transform.write('hello\n')
+    transform.write('world\n')
+    transform.end()
+
+    await finished(transform)
+
+    t.assert.strictEqual(data, 'HELLO\nWORLD\n')
   })
 
-  const peekStream = createLazyTransform(() => {
-    return upper
-  }, 3)
+  await t.test('uppercase no newline', async (t) => {
+    t.plan(2)
 
-  peekStream.on('data', (chunk) => chunks.push(chunk))
+    const transform = createPeekTransform(function (data) {
+      t.assert.strictEqual(data.toString(), 'helloworld')
+      return new UpperCaseTransform()
+    })
 
-  await new Promise((resolve, reject) => {
-    peekStream.on('end', resolve)
-    peekStream.on('error', reject)
-    peekStream.write(Buffer.from('hello'))
-    peekStream.end()
+    let data = ''
+    transform.on('data', (chunk) => { data += chunk.toString() })
+    transform.write('hello')
+    transform.write('world')
+    transform.end()
+
+    await finished(transform)
+
+    t.assert.strictEqual(data, 'HELLOWORLD')
   })
 
-  t.assert.equal(Buffer.concat(chunks).toString(), 'HELLO')
+  await t.test('error', async (t) => {
+    t.plan(2)
+
+    const transform = createPeekTransform(function (data) {
+      throw new Error('boom')
+    })
+
+    transform.on('data', (chunk) => { t.assert.fail('should not reach') })
+    transform.on('error', (error) => { t.assert.ok(error) })
+    transform.write('hello')
+    transform.write('world')
+    transform.end()
+
+    await t.assert.rejects(finished(transform), new Error('boom'))
+  })
+
+  await t.test('peekSize = 5', async (t) => {
+    t.plan(2)
+
+    const transform = createPeekTransform(function (data) {
+      t.assert.strictEqual(data.toString(), 'hello')
+      return new UpperCaseTransform()
+    }, 5)
+
+    let data = ''
+    transform.on('data', (chunk) => { data += chunk.toString() })
+    transform.write('hello\n')
+    transform.write('world\n')
+    transform.end()
+
+    await finished(transform)
+
+    t.assert.strictEqual(data, 'HELLO\nWORLD\n')
+  })
+
+  await t.test('data size < peekSize', async (t) => {
+    t.plan(2)
+
+    const transform = createPeekTransform(function (data) {
+      t.assert.strictEqual(data.toString(), 'helloworld')
+      return new UpperCaseTransform()
+    }, 100)
+
+    let data = ''
+    transform.on('data', (chunk) => { data += chunk.toString() })
+    transform.write('hello')
+    transform.write('world')
+    transform.end()
+
+    await finished(transform)
+
+    t.assert.strictEqual(data, 'HELLOWORLD')
+  })
 })


### PR DESCRIPTION
Inherit the work on #394 
Closes #394 
Fixes #393

- Remove `peek-stream`
- Replaced with `readable-stream` Transform

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
