### PR TITLE
perf: compress small buffered payloads synchronously

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,13 +211,21 @@ context per in-flight response — so it is retained in full even at the lowest 
 
 #### Raising it on CPU-constrained deployments
 
-`os.availableParallelism()` reports the host's cores and does not account for a cgroup CPU
-quota. A container limited to a fraction of a CPU on a large host therefore reads as "many
-cores" and gets the smallest default, even though it is precisely the deployment that
-benefits most from compressing synchronously — with little or no spare CPU, there is nothing
-for the streaming path to overlap with.
+Since libuv 1.49 (Node.js 22.12), `os.availableParallelism()` accounts for a cgroup CPU
+quota, so a container limited to whole cores reports those rather than the host's and gets
+an appropriate default on its own. Two cases still read as a wide host and so get the
+smallest default:
 
-If you run under a CPU limit, set `syncThreshold` explicitly:
+| deployment | reported | why |
+| --- | --- | --- |
+| Node.js before 22.12 | host cores | the quota is not consulted at all |
+| a quota below one core, e.g. Kubernetes `cpu: 500m` | host cores | the quota floors to zero and falls back to the host count |
+
+Both are precisely the deployments that benefit most from compressing synchronously: with
+little or no spare CPU, there is nothing for the streaming path to overlap with. Quotas are
+also floored rather than rounded, so `cpu: 2500m` reports two cores.
+
+If either applies to you, set `syncThreshold` explicitly:
 
 ```js
 await fastify.register(

--- a/README.md
+++ b/README.md
@@ -167,6 +167,34 @@ await fastify.register(
   { threshold: 2048 }
 )
 ```
+### syncThreshold
+The maximum byte size for compressing a response synchronously. Defaults to `32768` (32 KiB).
+
+Payloads that are already fully in memory (a `string` or a `Buffer`) and are not larger than
+`syncThreshold` are compressed in one call instead of being pushed through a compression
+stream. This is considerably faster for small responses — a per-response zlib stream costs
+more in setup and scheduling than the compression itself at these sizes — and it uses much
+less memory while the response is in flight, since no zlib context is allocated and the
+source payload is released immediately.
+
+Larger payloads, streams, [web `ReadableStream`s](#supported-payload-types) and fetch
+`Response`s always use the streaming path, so the event loop is never held for long. Raise
+`syncThreshold` to trade more event loop time for more throughput, or set it to `0` to
+compress every response through the streaming path.
+
+```js
+await fastify.register(
+  import('@fastify/compress'),
+  { syncThreshold: 65536 }
+)
+```
+
+Because the compressed size is known upfront, responses compressed synchronously carry an
+accurate `Content-Length` instead of being sent with chunked transfer encoding. Replies that
+already carry a `Content-Length` the plugin has been asked to keep
+(see [removeContentLengthHeader](#manage-content-length-header-removal-with-removecontentlengthheader))
+use the streaming path so the provided value is preserved.
+
 ### customTypes
 [mime-db](https://github.com/jshttp/mime-db) determines if a `content-type` should be compressed. Additional content types can be compressed via regex or a function.
 
@@ -267,6 +295,12 @@ By default, `@fastify/compress` removes the reply `Content-Length` header. Chang
     reply.compress(fs.createReadStream('./file.gz'))
   )
 ```
+
+This option exists because the streaming path cannot know the compressed size upfront, so
+the reply `Content-Length` would otherwise describe the uncompressed payload. Responses
+taking the [synchronous path](#syncthreshold) do know the compressed size and always send an
+accurate `Content-Length`; a reply that already carries a `Content-Length` and sets
+`removeContentLengthHeader` to `false` is streamed instead, so the provided value is kept.
 
 ## Usage - Decompress request payloads
 This plugin adds a `preParsing` hook to decompress the request payload based on the `content-encoding` request header.

--- a/README.md
+++ b/README.md
@@ -168,19 +168,19 @@ await fastify.register(
 )
 ```
 ### syncThreshold
-The maximum byte size for compressing a response synchronously. Defaults to `32768` (32 KiB).
+The maximum byte size for compressing a response synchronously. Defaults to a value derived
+from `os.availableParallelism()`, between `4096` and `65536`.
 
 Payloads that are already fully in memory (a `string` or a `Buffer`) and are not larger than
 `syncThreshold` are compressed in one call instead of being pushed through a compression
-stream. This is considerably faster for small responses — a per-response zlib stream costs
-more in setup and scheduling than the compression itself at these sizes — and it uses much
-less memory while the response is in flight, since no zlib context is allocated and the
-source payload is released immediately.
+stream. This is faster for small responses — a per-response zlib stream costs more in setup
+and scheduling than the compression itself at these sizes — and it uses much less memory
+while the response is in flight, since no zlib context is allocated and the source payload
+is released immediately.
 
 Larger payloads, streams, [web `ReadableStream`s](#supported-payload-types) and fetch
-`Response`s always use the streaming path, so the event loop is never held for long. Raise
-`syncThreshold` to trade more event loop time for more throughput, or set it to `0` to
-compress every response through the streaming path.
+`Response`s always use the streaming path, so the event loop is never held for long. Set
+`syncThreshold` to `0` to compress every response through the streaming path.
 
 ```js
 await fastify.register(
@@ -188,6 +188,48 @@ await fastify.register(
   { syncThreshold: 65536 }
 )
 ```
+
+#### How the default is chosen
+
+The streaming path hands compression to libuv's threadpool, so it only pays off when there
+are spare cores to overlap that work with the event loop. The more cores are available for
+that overlap, the smaller the payload at which streaming starts to win, so the default
+shrinks as the host gets wider:
+
+| cores reported | default |
+| --- | --- |
+| 1 | `65536` |
+| 2 | `8192` |
+| 3 or more | `4096` |
+
+The scale stops at four because libuv's threadpool defaults to four threads: beyond that,
+extra cores cannot compress any more responses in parallel. The value is computed once at
+startup and is always overridden by an explicit `syncThreshold`.
+
+The memory saving does not depend on payload size — it comes from not allocating a zlib
+context per in-flight response — so it is retained in full even at the lowest default.
+
+#### Raising it on CPU-constrained deployments
+
+`os.availableParallelism()` reports the host's cores and does not account for a cgroup CPU
+quota. A container limited to a fraction of a CPU on a large host therefore reads as "many
+cores" and gets the smallest default, even though it is precisely the deployment that
+benefits most from compressing synchronously — with little or no spare CPU, there is nothing
+for the streaming path to overlap with.
+
+If you run under a CPU limit, set `syncThreshold` explicitly:
+
+```js
+await fastify.register(
+  import('@fastify/compress'),
+  // a container pinned to ~1 CPU behaves like a single core host
+  { syncThreshold: 65536 }
+)
+```
+
+The default is biased towards the low end on purpose: choosing too low a value only forgoes
+part of the possible throughput gain, while choosing too high a value costs considerably
+more than it can ever return.
 
 Because the compressed size is known upfront, responses compressed synchronously carry an
 accurate `Content-Length` instead of being sent with chunked transfer encoding. Replies that

--- a/benchmark/sync-compression.mjs
+++ b/benchmark/sync-compression.mjs
@@ -1,0 +1,282 @@
+// Measures the synchronous compression path (`syncThreshold`) against the stream
+// pipeline it replaces for small buffered payloads.
+//
+//   node benchmark/sync-compression.mjs
+//   node benchmark/sync-compression.mjs --conns 100 --reps 5 --duration 8000
+//
+// Both configurations run against the same build: the baseline registers the plugin
+// with `syncThreshold: 0`, which always streams, and the candidate uses the default.
+//
+// A few things this harness deliberately does, because getting any of them wrong
+// produces numbers that look meaningful but are not:
+//
+//   * The server runs in a forked process. Compressing synchronously occupies the
+//     event loop, so a client sharing that loop would measure itself as much as
+//     the server.
+//   * Requests go over real sockets with real concurrency. `inject()` has neither,
+//     and cannot observe that the stream path hands work to the libuv threadpool
+//     and so overlaps with other cores.
+//   * Every size is measured several times, alternating between the two
+//     configurations, and reported as a median with its spread.
+//   * A control payload larger than the threshold is always included. Both
+//     configurations stream it, so its result must come out near zero. When it
+//     does not, the machine was too noisy and the whole run is rejected.
+
+import { fork } from 'node:child_process'
+import { createRequire } from 'node:module'
+import { availableParallelism, loadavg } from 'node:os'
+import { gzipSync } from 'node:zlib'
+import http from 'node:http'
+import { performance } from 'node:perf_hooks'
+
+const require = createRequire(import.meta.url)
+
+// Payload sizes must straddle the threshold: the last one is the control.
+const CONTROL_SIZE = 131072
+const DEFAULT_SIZES = [1024, 2048, 4096, 8192, CONTROL_SIZE]
+// Above this, the control row is too far off for the run to mean anything.
+const CONTROL_TOLERANCE = 0.1
+const TARGET_RATIO = 8
+
+function parseArgs (argv) {
+  const args = {
+    conns: 50,
+    duration: 5000,
+    reps: 3,
+    warmup: 1000,
+    sizes: DEFAULT_SIZES
+  }
+  for (let i = 0; i < argv.length; i += 2) {
+    const key = argv[i].replace(/^--/, '')
+    const value = argv[i + 1]
+    if (!(key in args)) throw new Error(`Unknown option: ${argv[i]}`)
+    args[key] = key === 'sizes'
+      ? value.split(',').map(Number)
+      : Number(value)
+  }
+  return args
+}
+
+// Deterministic payload with a realistic compression ratio. Content structure drives
+// compression cost far more than length does, so a fixed ratio keeps sizes comparable.
+function makePayload (byteCount, randomFraction) {
+  const data = Buffer.alloc(byteCount)
+  let state = 0x12345678
+  for (let i = 0; i < byteCount; i++) {
+    state = (Math.imul(state, 1664525) + 1013904223) >>> 0
+    if (state / 0x100000000 < randomFraction) data[i] = state >>> 24
+  }
+  return data
+}
+
+function makePayloadAtRatio (byteCount, ratio) {
+  let low = 0
+  let high = 1
+  let best
+  for (let i = 0; i < 20; i++) {
+    const fraction = (low + high) / 2
+    const payload = makePayload(byteCount, fraction)
+    const actual = byteCount / gzipSync(payload).byteLength
+    if (!best || Math.abs(actual - ratio) < Math.abs(best.ratio - ratio)) {
+      best = { payload, ratio: actual }
+    }
+    if (actual > ratio) low = fraction
+    else high = fraction
+  }
+  return best
+}
+
+/* ------------------------------------------------------------------ server role */
+
+if (process.env.BENCHMARK_ROLE === 'server') {
+  const Fastify = require('fastify')
+  const compress = require('../index.js')
+
+  const size = Number(process.env.BENCHMARK_SIZE)
+  const syncThreshold = process.env.BENCHMARK_SYNC_THRESHOLD === 'default'
+    ? undefined
+    : Number(process.env.BENCHMARK_SYNC_THRESHOLD)
+
+  const { payload } = makePayloadAtRatio(size, TARGET_RATIO)
+  const body = payload.toString('latin1')
+
+  const app = Fastify()
+  const options = { global: true }
+  if (syncThreshold !== undefined) options.syncThreshold = syncThreshold
+  await app.register(compress, options)
+
+  app.get('/payload', async (_request, reply) => {
+    reply.type('text/plain')
+    return body
+  })
+
+  const address = await app.listen({ port: 0, host: '127.0.0.1' })
+  const port = Number(new URL(address).port)
+
+  process.on('message', (message) => {
+    if (message === 'rss') process.send({ rssMiB: process.memoryUsage().rss / 1048576 })
+  })
+  process.send({ ready: true, port })
+} else {
+  await main()
+}
+
+/* ------------------------------------------------------------------ client role */
+
+function startServer (size, syncThreshold) {
+  return new Promise((resolve, reject) => {
+    const child = fork(import.meta.filename, [], {
+      env: {
+        ...process.env,
+        BENCHMARK_ROLE: 'server',
+        BENCHMARK_SIZE: String(size),
+        BENCHMARK_SYNC_THRESHOLD: String(syncThreshold)
+      },
+      stdio: ['ignore', 'ignore', 'inherit', 'ipc']
+    })
+    const onMessage = (message) => {
+      if (message.ready) {
+        child.off('message', onMessage)
+        resolve({ child, port: message.port })
+      }
+    }
+    child.on('message', onMessage)
+    child.once('error', reject)
+    child.once('exit', (code) => reject(new Error(`benchmark server exited early (${code})`)))
+  })
+}
+
+function rssOf (child) {
+  return new Promise((resolve) => {
+    const onMessage = (message) => {
+      if (message.rssMiB !== undefined) {
+        child.off('message', onMessage)
+        resolve(message.rssMiB)
+      }
+    }
+    child.on('message', onMessage)
+    child.send('rss')
+  })
+}
+
+function get (port, agent) {
+  return new Promise((resolve, reject) => {
+    const request = http.get(
+      { host: '127.0.0.1', port, path: '/payload', agent, headers: { 'accept-encoding': 'gzip' } },
+      (response) => {
+        response.resume()
+        response.once('end', () => resolve(response.headers['content-encoding']))
+        response.once('error', reject)
+      }
+    )
+    request.once('error', reject)
+  })
+}
+
+async function measure (port, { conns, duration, warmup }) {
+  const agent = new http.Agent({ keepAlive: true, maxSockets: conns })
+  const countFrom = performance.now() + warmup
+  const stopAt = countFrom + duration
+  let completed = 0
+  let encoding
+
+  // Requests keep flowing across the warmup boundary, so the measured window sees a
+  // server already at steady state rather than one still filling its connection pool.
+  const workers = Array.from({ length: conns }, async () => {
+    while (performance.now() < stopAt) {
+      encoding = await get(port, agent)
+      if (performance.now() >= countFrom) completed++
+    }
+  })
+
+  await Promise.all(workers)
+  agent.destroy()
+
+  return { reqPerSec: completed / (duration / 1000), encoding }
+}
+
+async function runCase (size, syncThreshold, args) {
+  const { child, port } = await startServer(size, syncThreshold)
+  try {
+    const result = await measure(port, args)
+    return { ...result, rssMiB: await rssOf(child) }
+  } finally {
+    child.kill('SIGKILL')
+  }
+}
+
+// Declared as a function so it is hoisted above the top-level `main()` call.
+function median (values) {
+  const sorted = [...values].sort((a, b) => a - b)
+  return sorted[Math.floor(sorted.length / 2)]
+}
+
+function formatSize (bytes) {
+  return bytes >= 1024 ? `${bytes / 1024} KiB` : `${bytes} B`
+}
+
+async function main () {
+  const args = parseArgs(process.argv.slice(2))
+  const { computeSyncThreshold } = require('../lib/utils.js')
+  const cores = availableParallelism()
+  const computed = computeSyncThreshold()
+
+  console.log('@fastify/compress — synchronous compression path')
+  console.log(`node ${process.version}  ${process.platform}/${process.arch}  ${cores} cores`)
+  console.log(`computed default syncThreshold: ${computed} bytes`)
+  console.log(`${args.conns} connections, ${args.duration} ms x ${args.reps} reps, target ratio ${TARGET_RATIO}:1\n`)
+
+  const load = loadavg()[0]
+  if (load > cores / 4) {
+    console.log(`WARNING: 1-minute load average is ${load.toFixed(2)} on ${cores} cores.`)
+    console.log('Results from a busy machine are not meaningful. Wait for it to settle.\n')
+  }
+
+  const results = new Map(args.sizes.map((size) => [size, { baseline: [], candidate: [] }]))
+
+  for (let rep = 1; rep <= args.reps; rep++) {
+    for (const size of args.sizes) {
+      // Alternate within a rep so slow drift hits both configurations equally.
+      const baseline = await runCase(size, 0, args)
+      const candidate = await runCase(size, 'default', args)
+      if (baseline.encoding !== 'gzip' || candidate.encoding !== 'gzip') {
+        throw new Error(`payload of ${size} B was not compressed — check the plugin threshold`)
+      }
+      results.get(size).baseline.push(baseline)
+      results.get(size).candidate.push(candidate)
+    }
+    console.log(`rep ${rep}/${args.reps} done`)
+  }
+
+  console.log('\npayload      streamed r/s   default r/s     change   streamed RSS   default RSS')
+  let controlChange = 0
+  for (const size of args.sizes) {
+    const { baseline, candidate } = results.get(size)
+    const base = median(baseline.map((r) => r.reqPerSec))
+    const cand = median(candidate.map((r) => r.reqPerSec))
+    const change = cand / base - 1
+    const isControl = size > Math.max(computed, ...args.sizes.filter((s) => s <= computed))
+    if (isControl) controlChange = Math.max(controlChange, Math.abs(change))
+    console.log(
+      formatSize(size).padEnd(12) +
+      base.toFixed(0).padStart(12) +
+      cand.toFixed(0).padStart(14) +
+      `${(change * 100).toFixed(0)}%`.padStart(11) +
+      `${median(baseline.map((r) => r.rssMiB)).toFixed(0)} MiB`.padStart(15) +
+      `${median(candidate.map((r) => r.rssMiB)).toFixed(0)} MiB`.padStart(14) +
+      (isControl ? '   <- control, expect ~0%' : '')
+    )
+  }
+
+  // The control streams in both configurations, so anything other than a near-zero
+  // result means the measurement environment, not the plugin, moved the numbers.
+  console.log('')
+  if (controlChange > CONTROL_TOLERANCE) {
+    console.log(`REJECTED: control moved by ${(controlChange * 100).toFixed(0)}%, above the ${CONTROL_TOLERANCE * 100}% tolerance.`)
+    console.log('Both configurations stream that payload, so the difference is machine noise.')
+    console.log('Re-run on an idle machine, or raise --reps, before drawing conclusions.')
+    process.exitCode = 1
+  } else {
+    console.log(`Control within ${(CONTROL_TOLERANCE * 100).toFixed(0)}% — run looks valid.`)
+  }
+}

--- a/index.js
+++ b/index.js
@@ -127,9 +127,10 @@ function processCompressParams (opts) {
   }
 
   params.removeContentLengthHeader = typeof opts.removeContentLengthHeader === 'boolean' ? opts.removeContentLengthHeader : true
-  params.brotliOptions = params.global
-    ? { ...recommendedDefaultBrotliOptions, ...opts.brotliOptions }
-    : opts.brotliOptions
+  // The recommended defaults apply whatever the value of `global` is: with
+  // `global: false` the compression still runs, just through `reply.compress()`,
+  // and falling back to zlib's default quality of 11 there is needlessly slow.
+  params.brotliOptions = { ...recommendedDefaultBrotliOptions, ...opts.brotliOptions }
   params.zlibOptions = opts.zlibOptions
   params.onUnsupportedEncoding = opts.onUnsupportedEncoding
   params.inflateIfDeflated = opts.inflateIfDeflated === true

--- a/index.js
+++ b/index.js
@@ -135,6 +135,11 @@ function processCompressParams (opts) {
   params.onUnsupportedEncoding = opts.onUnsupportedEncoding
   params.inflateIfDeflated = opts.inflateIfDeflated === true
   params.threshold = typeof opts.threshold === 'number' ? opts.threshold : 1024
+  // Upper size bound of the synchronous compression path. Unlike `threshold`, which is a
+  // lower bound, this one is a ceiling: bigger payloads keep using the stream pipeline.
+  // 32 KiB keeps the inline work down to roughly a millisecond, which is where the
+  // throughput win over a per-response zlib stream is largest. `0` disables the path.
+  params.syncThreshold = typeof opts.syncThreshold === 'number' ? opts.syncThreshold : 32768
   params.compressibleTypes = opts.customTypes instanceof RegExp
     ? opts.customTypes.test.bind(opts.customTypes)
     : typeof opts.customTypes === 'function'
@@ -148,6 +153,22 @@ function processCompressParams (opts) {
   if (typeof ((opts.zlib || zlib).createZstdCompress || zlib.createZstdCompress) === 'function') {
     params.compressStream.zstd = () => ((opts.zlib || zlib).createZstdCompress || zlib.createZstdCompress)(params.zlibOptions)
   }
+  // Synchronous counterparts of `params.compressStream`, used for small buffered payloads.
+  // Encodings without a usable synchronous method are left out of the map so that they
+  // keep flowing through the stream pipeline.
+  params.compressSync = {}
+  for (const [encoding, streamMethod, syncMethod, options] of [
+    ['br', 'createBrotliCompress', 'brotliCompressSync', params.brotliOptions],
+    ['gzip', 'createGzip', 'gzipSync', params.zlibOptions],
+    ['deflate', 'createDeflate', 'deflateSync', params.zlibOptions],
+    ['zstd', 'createZstdCompress', 'zstdCompressSync', params.zlibOptions]
+  ]) {
+    const compressSync = resolveSyncCompressor(opts.zlib, streamMethod, syncMethod, options)
+    if (compressSync !== undefined) {
+      params.compressSync[encoding] = compressSync
+    }
+  }
+
   params.uncompressStream = {
     // Currently params.uncompressStream.br() is never called as we do not have any way to autodetect brotli compression in `fastify-compress`
     // Brotli documentation reference: [RFC 7932](https://www.rfc-editor.org/rfc/rfc7932)
@@ -173,6 +194,54 @@ function processCompressParams (opts) {
     : supportedEncodings
 
   return params
+}
+
+// Resolve the synchronous counterpart of a stream compressor.
+// A synchronous method is only picked when it comes from the same `zlib` implementation the
+// stream path would have used, so a custom `zlib` exposing just the stream constructor is
+// never bypassed: its encoding simply keeps using the stream pipeline.
+function resolveSyncCompressor (customZlib, streamMethod, syncMethod, options) {
+  let compressSync
+
+  if (customZlib != null && typeof customZlib[syncMethod] === 'function') {
+    compressSync = customZlib[syncMethod]
+  } else if ((customZlib == null || typeof customZlib[streamMethod] !== 'function') && typeof zlib[syncMethod] === 'function') {
+    // `zlib.zstdCompressSync` is only available on Node.js 22.15+/23.8+
+    compressSync = zlib[syncMethod]
+  } else {
+    return undefined
+  }
+
+  return (payload) => compressSync(payload, options)
+}
+
+// Compress an already buffered payload inline, bypassing the stream pipeline.
+// Small payloads are much cheaper to compress this way: no zlib context and no stream
+// pipeline are allocated per response, and the source payload is released immediately
+// instead of being pinned for as long as the response is in flight.
+// Returns `null` when the payload is not eligible and must be streamed instead.
+function compressPayloadSync (params, reply, encoding, payload, payloadSize) {
+  if (params.syncThreshold <= 0 || payloadSize > params.syncThreshold) return null
+
+  const compressSync = params.compressSync[encoding]
+  if (compressSync === undefined) return null
+
+  // Only strings and Buffers are fully buffered and can be compressed in one go.
+  // Fastify already turns every other buffered payload type into one of those two
+  // before this point, so this is a safety net rather than a reachable path.
+  /* c8 ignore next */
+  if (typeof payload !== 'string' && !Buffer.isBuffer(payload)) return null
+
+  // Fastify recomputes `content-length` for buffered payloads, so a caller provided value
+  // that the plugin has been asked to keep can only be honoured by the stream path
+  if (params.removeContentLengthHeader === false && reply.getHeader('content-length') !== undefined) return null
+
+  const buffer = Buffer.isBuffer(payload) ? payload : Buffer.from(payload)
+
+  // Mirror `zipStream()` and pass already gzip or deflate compressed payloads through as is
+  if (isCompressed(buffer) !== 0) return buffer
+
+  return compressSync(buffer)
 }
 
 function processDecompressParams (opts) {
@@ -303,9 +372,27 @@ function buildRouteCompress (_fastify, params, routeOptions, decorateOnly) {
       if (isWebReadableStream(payload)) {
         payload = webStreamToNodeReadable(payload)
       } else {
-        if (Buffer.byteLength(payload) < params.threshold) {
+        const payloadSize = Buffer.byteLength(payload)
+        if (payloadSize < params.threshold) {
           return next()
         }
+
+        let compressedPayload = null
+        try {
+          compressedPayload = compressPayloadSync(params, reply, encoding, payload, payloadSize)
+        } catch (err) {
+          return next(err)
+        }
+
+        if (compressedPayload !== null) {
+          setVaryHeader(reply)
+          reply.header('Content-Encoding', encoding)
+          // The compressed size is known on this path, so an accurate `content-length` is
+          // set instead of dropping the header and falling back to a chunked response
+          reply.header('Content-Length', compressedPayload.length)
+          return next(null, compressedPayload)
+        }
+
         payload = Readable.from(intoAsyncIterator(payload))
       }
     }
@@ -437,9 +524,27 @@ function compress (params) {
     }
 
     if (typeof payload.pipe !== 'function') {
-      if (Buffer.byteLength(payload) < params.threshold) {
+      const payloadSize = Buffer.byteLength(payload)
+      if (payloadSize < params.threshold) {
         return this.send(payload)
       }
+
+      let compressedPayload = null
+      try {
+        compressedPayload = compressPayloadSync(params, this, encoding, payload, payloadSize)
+      } catch (err) {
+        return this.send(err)
+      }
+
+      if (compressedPayload !== null) {
+        setVaryHeader(this)
+        this.header('Content-Encoding', encoding)
+        // The compressed size is known on this path, so an accurate `content-length` is
+        // set instead of dropping the header and falling back to a chunked response
+        this.header('Content-Length', compressedPayload.length)
+        return this.send(compressedPayload)
+      }
+
       payload = Readable.from(intoAsyncIterator(payload))
     }
 

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ const { Minipass } = require('minipass')
 const { Readable } = require('readable-stream')
 
 const {
+  computeSyncThreshold,
   isStream,
   isGzip,
   isDeflate,
@@ -20,6 +21,10 @@ const {
   webStreamToNodeReadable,
   createPeekTransform
 } = require('./lib/utils')
+
+// The default depends on how much parallelism the host offers, which cannot change while
+// the process runs, so it is computed once here rather than per registration or per request
+const defaultSyncThreshold = computeSyncThreshold()
 
 const InvalidRequestEncodingError = createError('FST_CP_ERR_INVALID_CONTENT_ENCODING', 'Unsupported Content-Encoding: %s', 415)
 const InvalidRequestCompressedPayloadError = createError('FST_CP_ERR_INVALID_CONTENT', 'Could not decompress the request payload using the provided encoding', 400)
@@ -137,9 +142,10 @@ function processCompressParams (opts) {
   params.threshold = typeof opts.threshold === 'number' ? opts.threshold : 1024
   // Upper size bound of the synchronous compression path. Unlike `threshold`, which is a
   // lower bound, this one is a ceiling: bigger payloads keep using the stream pipeline.
-  // 32 KiB keeps the inline work down to roughly a millisecond, which is where the
-  // throughput win over a per-response zlib stream is largest. `0` disables the path.
-  params.syncThreshold = typeof opts.syncThreshold === 'number' ? opts.syncThreshold : 32768
+  // The default scales with the parallelism the host can offer the stream path, see
+  // `computeSyncThreshold()`. An explicit value is always used as is, and `0` disables
+  // the synchronous path entirely.
+  params.syncThreshold = typeof opts.syncThreshold === 'number' ? opts.syncThreshold : defaultSyncThreshold
   params.compressibleTypes = opts.customTypes instanceof RegExp
     ? opts.customTypes.test.bind(opts.customTypes)
     : typeof opts.customTypes === 'function'

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,7 +1,41 @@
 'use strict'
 
 const { Readable: NodeReadable } = require('node:stream')
+const { availableParallelism } = require('node:os')
 const { Transform } = require('readable-stream')
+
+// Bounds of the computed default synchronous compression threshold
+const MIN_SYNC_THRESHOLD = 4096
+const MAX_SYNC_THRESHOLD = 65536
+// libuv's threadpool defaults to 4 threads, so at most 4 stream compressions can make
+// progress at once however many cores the host reports. `UV_THREADPOOL_SIZE` can raise
+// it, but it is not something this default can rely on.
+const MAX_USEFUL_PARALLELISM = 4
+
+/**
+ * Compute the default upper size bound of the synchronous compression path.
+ *
+ * The stream path hands compression to the libuv threadpool, so it only pays off when
+ * there are spare cores to overlap that work with the event loop. The more cores are
+ * available for that overlap, the smaller the payload at which streaming starts winning:
+ * measured over real sockets, the crossover sits around 4 KiB with four or more cores,
+ * while on a single core the synchronous path stays ahead across the whole range.
+ *
+ * The threshold is therefore divided by 8 for every core beyond the first, and clamped.
+ * The divisor is deliberately steep because the two errors are not symmetric: settling
+ * too low only forgoes some of the throughput win, while settling too high costs far
+ * more than it ever gains.
+ *
+ * `availableParallelism()` reports the host's cores and ignores any cgroup CPU quota, so
+ * a CPU limited container on a big host reads as "many cores" and gets the low end of the
+ * range. That is the safe way to be wrong, and such deployments can raise `syncThreshold`
+ * explicitly.
+ */
+function computeSyncThreshold (parallelism = availableParallelism()) {
+  const usableCores = Math.min(parallelism, MAX_USEFUL_PARALLELISM)
+  const threshold = MAX_SYNC_THRESHOLD >> (3 * (usableCores - 1))
+  return Math.min(Math.max(threshold, MIN_SYNC_THRESHOLD), MAX_SYNC_THRESHOLD)
+}
 
 // https://datatracker.ietf.org/doc/html/rfc8878#section-3.1.1
 function isZstd (buffer) {
@@ -184,6 +218,7 @@ function createPeekTransform (swapStream, peekSize = 10) {
 }
 
 module.exports = {
+  computeSyncThreshold,
   isZstd,
   isGzip,
   isDeflate,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -26,10 +26,16 @@ const MAX_USEFUL_PARALLELISM = 4
  * too low only forgoes some of the throughput win, while settling too high costs far
  * more than it ever gains.
  *
- * `availableParallelism()` reports the host's cores and ignores any cgroup CPU quota, so
- * a CPU limited container on a big host reads as "many cores" and gets the low end of the
- * range. That is the safe way to be wrong, and such deployments can raise `syncThreshold`
- * explicitly.
+ * `availableParallelism()` accounts for a cgroup CPU quota since libuv 1.49 (Node 22.12),
+ * so a container limited to whole cores reports those rather than the host's. Two cases
+ * still read as a wide host and so land on the low end of the range:
+ *
+ *   - Node.js before 22.12, where the quota is not consulted at all;
+ *   - a quota below one full core, such as Kubernetes `cpu: 500m`, which floors to zero
+ *     and falls back to the host's core count.
+ *
+ * Both err towards the small end, which is the safe direction: settling too low only
+ * forgoes some of the win. Such deployments can raise `syncThreshold` explicitly.
  */
 function computeSyncThreshold (parallelism = availableParallelism()) {
   const usableCores = Math.min(parallelism, MAX_USEFUL_PARALLELISM)

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
   "scripts": {
     "lint": "eslint",
     "lint:fix": "eslint --fix",
+    "benchmark": "node benchmark/sync-compression.mjs",
     "test": "npm run test:unit && npm run test:typescript",
     "test:typescript": "tstyche",
     "test:unit": "node --test",

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -2821,6 +2821,70 @@ describe('It should send data compressed according to `brotliOptions` :', async 
     const compressedPayload = zlib.brotliCompressSync(file, defaultBrotliOptions)
     t.assert.deepEqual(response.rawPayload, compressedPayload)
   })
+
+  test('default BROTLI_PARAM_QUALITY to be 4 when `global` is `false`', async (t) => {
+    t.plan(2)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: false })
+
+    const file = readFileSync('./package.json', 'utf8')
+    fastify.get('/', (_request, reply) => {
+      reply
+        .type('text/plain')
+        .compress(file)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: {
+        'accept-encoding': 'br'
+      }
+    })
+
+    const defaultBrotliOptions = {
+      params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 4 }
+    }
+    const compressedPayload = zlib.brotliCompressSync(file, defaultBrotliOptions)
+    t.assert.deepEqual(response.rawPayload, compressedPayload)
+
+    // zlib's own default of quality 11 is far more expensive and must not be used
+    const maxQualityPayload = zlib.brotliCompressSync(file)
+    t.assert.notDeepEqual(response.rawPayload, maxQualityPayload)
+  })
+
+  test('user supplied `brotliOptions` still take precedence when `global` is `false`', async (t) => {
+    t.plan(1)
+
+    const brotliOptions = {
+      params: {
+        [zlib.constants.BROTLI_PARAM_MODE]: zlib.constants.BROTLI_MODE_TEXT,
+        [zlib.constants.BROTLI_PARAM_QUALITY]: 8
+      }
+    }
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: false, brotliOptions })
+
+    const file = readFileSync('./package.json', 'utf8')
+    fastify.get('/', (_request, reply) => {
+      reply
+        .type('text/plain')
+        .compress(file)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: {
+        'accept-encoding': 'br'
+      }
+    })
+
+    const compressedPayload = zlib.brotliCompressSync(file, brotliOptions)
+    t.assert.deepEqual(response.rawPayload, compressedPayload)
+  })
 })
 
 describe('It should send data compressed according to `zlibOptions` :', async () => {

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -2005,11 +2005,14 @@ describe('It should support stream1 :', async () => {
 })
 
 describe('It should remove `Content-Length` header :', async () => {
+  // `./package.json` is small enough to be compressed synchronously, and the synchronous
+  // path knows the compressed size, so it replaces the stale `Content-Length` with an
+  // accurate one instead of removing it. `syncThreshold: 0` restores the streamed behaviour.
   test('using `reply.compress()`', async (t) => {
     t.plan(4)
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true })
+    await fastify.register(compressPlugin, { global: true, syncThreshold: 0 })
 
     fastify.get('/', (_request, reply) => {
       readFile('./package.json', 'utf8', (err, data) => {
@@ -2069,7 +2072,7 @@ describe('It should remove `Content-Length` header :', async () => {
     t.plan(4)
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true })
+    await fastify.register(compressPlugin, { global: true, syncThreshold: 0 })
 
     fastify.get('/', (_request, reply) => {
       readFile('./package.json', 'utf8', (err, data) => {

--- a/test/regression/issue-350.test.js
+++ b/test/regression/issue-350.test.js
@@ -22,7 +22,9 @@ async function routes (fastify) {
 
 test('should compress large payload without premature close', async (t) => {
   const fastify = Fastify()
-  await fastify.register(fastifyCompress, { encodings: ['gzip'], global: true })
+  // `syncThreshold: 0` keeps this payload on the stream pipeline this regression covers,
+  // whatever default the host parallelism would otherwise produce
+  await fastify.register(fastifyCompress, { encodings: ['gzip'], global: true, syncThreshold: 0 })
   await fastify.register(routes)
 
   const response = await fastify.inject({

--- a/test/sync-compress.test.js
+++ b/test/sync-compress.test.js
@@ -1,0 +1,645 @@
+'use strict'
+
+const { describe, test } = require('node:test')
+const { createReadStream } = require('node:fs')
+const { randomBytes } = require('node:crypto')
+const zlib = require('node:zlib')
+const Fastify = require('fastify')
+const compressPlugin = require('../index')
+
+// A compressible body of a given size, so tests can pick which side of
+// `threshold` / `syncThreshold` a payload falls on
+function buildPayload (size) {
+  return 'the quick brown fox jumps over the lazy dog '.repeat(Math.ceil(size / 44)).slice(0, size)
+}
+
+const smallPayload = buildPayload(4096)
+const largePayload = buildPayload(200 * 1024)
+// incompressible, so that the already compressed payloads built from it stay
+// comfortably above the default `threshold` and below the default `syncThreshold`
+const incompressiblePayload = randomBytes(4096)
+
+describe('When a buffered payload fits within `syncThreshold`, it should be compressed synchronously :', async () => {
+  test('using gzip', async (t) => {
+    t.plan(4)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.headers.vary, 'accept-encoding')
+    t.assert.equal(response.headers['content-encoding'], 'gzip')
+    t.assert.equal(response.headers['content-length'], response.rawPayload.length.toString())
+    t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), smallPayload)
+  })
+
+  test('using deflate', async (t) => {
+    t.plan(4)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'deflate' }
+    })
+    t.assert.equal(response.headers.vary, 'accept-encoding')
+    t.assert.equal(response.headers['content-encoding'], 'deflate')
+    t.assert.equal(response.headers['content-length'], response.rawPayload.length.toString())
+    t.assert.equal(zlib.inflateSync(response.rawPayload).toString('utf-8'), smallPayload)
+  })
+
+  test('using brotli', async (t) => {
+    t.plan(4)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'br' }
+    })
+    t.assert.equal(response.headers.vary, 'accept-encoding')
+    t.assert.equal(response.headers['content-encoding'], 'br')
+    t.assert.equal(response.headers['content-length'], response.rawPayload.length.toString())
+    t.assert.equal(zlib.brotliDecompressSync(response.rawPayload).toString('utf-8'), smallPayload)
+  })
+
+  test('using zstd', async (t) => {
+    if (typeof zlib.createZstdCompress !== 'function') {
+      t.skip('zstd not supported in this Node.js version')
+      return
+    }
+    t.plan(4)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'zstd' }
+    })
+    t.assert.equal(response.headers.vary, 'accept-encoding')
+    t.assert.equal(response.headers['content-encoding'], 'zstd')
+    t.assert.equal(response.headers['content-length'], response.rawPayload.length.toString())
+    t.assert.equal(zlib.zstdDecompressSync(response.rawPayload).toString('utf-8'), smallPayload)
+  })
+
+  test('using a Buffer payload', async (t) => {
+    t.plan(3)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true })
+
+    const buf = Buffer.from(smallPayload)
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(buf)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.headers['content-encoding'], 'gzip')
+    t.assert.equal(response.headers['content-length'], response.rawPayload.length.toString())
+    t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), smallPayload)
+  })
+
+  test('using `reply.compress()`', async (t) => {
+    t.plan(4)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: false })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').compress(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.headers.vary, 'accept-encoding')
+    t.assert.equal(response.headers['content-encoding'], 'gzip')
+    t.assert.equal(response.headers['content-length'], response.rawPayload.length.toString())
+    t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), smallPayload)
+  })
+
+  test('using a route level `compress` configuration', async (t) => {
+    t.plan(3)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: false })
+
+    fastify.get('/', {
+      compress: { syncThreshold: 8192 }
+    }, (_request, reply) => {
+      reply.type('text/plain').send(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.headers['content-encoding'], 'gzip')
+    t.assert.equal(response.headers['content-length'], response.rawPayload.length.toString())
+    t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), smallPayload)
+  })
+
+  test('it should honour `zlibOptions`', async (t) => {
+    t.plan(2)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true, zlibOptions: { level: 9 } })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), smallPayload)
+    t.assert.equal(response.rawPayload.length, zlib.gzipSync(smallPayload, { level: 9 }).length)
+  })
+
+  test('it should honour `brotliOptions`', async (t) => {
+    t.plan(2)
+
+    const brotliOptions = { params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 11 } }
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true, brotliOptions })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'br' }
+    })
+    t.assert.equal(zlib.brotliDecompressSync(response.rawPayload).toString('utf-8'), smallPayload)
+    t.assert.equal(response.rawPayload.length, zlib.brotliCompressSync(smallPayload, brotliOptions).length)
+  })
+})
+
+describe('It should fall back to the stream pipeline when the payload is not eligible :', async () => {
+  test('when the payload is smaller than `threshold`', async (t) => {
+    t.plan(3)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send('hello world')
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.ok(!response.headers.vary)
+    t.assert.ok(!response.headers['content-encoding'])
+    t.assert.equal(response.payload, 'hello world')
+  })
+
+  test('when the payload is bigger than `syncThreshold`', async (t) => {
+    t.plan(4)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(largePayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.headers.vary, 'accept-encoding')
+    t.assert.equal(response.headers['content-encoding'], 'gzip')
+    // the streamed path cannot know the compressed size upfront
+    t.assert.ok(!response.headers['content-length'], 'no content length')
+    t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), largePayload)
+  })
+
+  test('when `syncThreshold` is `0`', async (t) => {
+    t.plan(4)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true, syncThreshold: 0 })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.headers.vary, 'accept-encoding')
+    t.assert.equal(response.headers['content-encoding'], 'gzip')
+    t.assert.ok(!response.headers['content-length'], 'no content length')
+    t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), smallPayload)
+  })
+
+  test('when `syncThreshold` is `0` using `reply.compress()`', async (t) => {
+    t.plan(3)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: false, syncThreshold: 0 })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').compress(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.headers['content-encoding'], 'gzip')
+    t.assert.ok(!response.headers['content-length'], 'no content length')
+    t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), smallPayload)
+  })
+
+  test('when the payload is a Stream', async (t) => {
+    t.plan(3)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(createReadStream('./package.json'))
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.headers['content-encoding'], 'gzip')
+    t.assert.ok(!response.headers['content-length'], 'no content length')
+    t.assert.ok(zlib.gunzipSync(response.rawPayload).length > 0)
+  })
+
+  test('when the payload is a Web ReadableStream', async (t) => {
+    t.plan(3)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true })
+
+    fastify.get('/', (_request, reply) => {
+      const stream = new ReadableStream({
+        start (controller) {
+          controller.enqueue(new TextEncoder().encode(smallPayload))
+          controller.close()
+        }
+      })
+      reply.type('text/plain').send(stream)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.headers['content-encoding'], 'gzip')
+    t.assert.ok(!response.headers['content-length'], 'no content length')
+    t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), smallPayload)
+  })
+
+  test('when a custom `zlib` provides no synchronous method', async (t) => {
+    t.plan(4)
+
+    let usedCustom = false
+    const customZlib = { createGzip: () => (usedCustom = true) && zlib.createGzip() }
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true, zlib: customZlib })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(usedCustom, true)
+    t.assert.equal(response.headers['content-encoding'], 'gzip')
+    t.assert.ok(!response.headers['content-length'], 'no content length')
+    t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), smallPayload)
+  })
+
+  test('when a custom `zlib` provides no synchronous method using `reply.compress()`', async (t) => {
+    t.plan(3)
+
+    let usedCustom = false
+    const customZlib = { createDeflate: () => (usedCustom = true) && zlib.createDeflate() }
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: false, zlib: customZlib })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').compress(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'deflate' }
+    })
+    t.assert.equal(usedCustom, true)
+    t.assert.ok(!response.headers['content-length'], 'no content length')
+    t.assert.equal(zlib.inflateSync(response.rawPayload).toString('utf-8'), smallPayload)
+  })
+
+  test('when `removeContentLengthHeader` is `false` and the reply already carries a `Content-Length`', async (t) => {
+    t.plan(3)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true, removeContentLengthHeader: false })
+
+    fastify.get('/', (_request, reply) => {
+      reply
+        .type('text/plain')
+        .header('content-length', '' + Buffer.byteLength(smallPayload))
+        .send(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.headers['content-encoding'], 'gzip')
+    // the caller provided value is preserved, as it is on the streamed path
+    t.assert.equal(response.headers['content-length'], Buffer.byteLength(smallPayload).toString())
+    t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), smallPayload)
+  })
+})
+
+describe('When `syncThreshold` is `0`, every encoding should keep using the stream pipeline :', async () => {
+  // a custom `zlib` exposing an unrelated method only: every encoding falls back
+  // to the native stream compressor, exactly as it did before the synchronous path
+  const customZlib = { createGunzip: zlib.createGunzip }
+
+  for (const [encoding, decompress] of [
+    ['br', zlib.brotliDecompressSync],
+    ['gzip', zlib.gunzipSync],
+    ['deflate', zlib.inflateSync]
+  ]) {
+    test(`using ${encoding} with a custom \`zlib\``, async (t) => {
+      t.plan(3)
+
+      const fastify = Fastify()
+      await fastify.register(compressPlugin, { global: true, zlib: customZlib, syncThreshold: 0 })
+
+      fastify.get('/', (_request, reply) => {
+        reply.type('text/plain').send(smallPayload)
+      })
+
+      const response = await fastify.inject({
+        url: '/',
+        method: 'GET',
+        headers: { 'accept-encoding': encoding }
+      })
+      t.assert.equal(response.headers['content-encoding'], encoding)
+      t.assert.ok(!response.headers['content-length'], 'no content length')
+      t.assert.equal(decompress(response.rawPayload).toString('utf-8'), smallPayload)
+    })
+  }
+
+  test('using zstd with a custom `zlib`', async (t) => {
+    if (typeof zlib.createZstdCompress !== 'function') {
+      t.skip('zstd not supported in this Node.js version')
+      return
+    }
+    t.plan(3)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true, zlib: customZlib, syncThreshold: 0 })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'zstd' }
+    })
+    t.assert.equal(response.headers['content-encoding'], 'zstd')
+    t.assert.ok(!response.headers['content-length'], 'no content length')
+    t.assert.equal(zlib.zstdDecompressSync(response.rawPayload).toString('utf-8'), smallPayload)
+  })
+
+  test('using zstd with the native `zlib`', async (t) => {
+    if (typeof zlib.createZstdCompress !== 'function') {
+      t.skip('zstd not supported in this Node.js version')
+      return
+    }
+    t.plan(3)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true, syncThreshold: 0 })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'zstd' }
+    })
+    t.assert.equal(response.headers['content-encoding'], 'zstd')
+    t.assert.ok(!response.headers['content-length'], 'no content length')
+    t.assert.equal(zlib.zstdDecompressSync(response.rawPayload).toString('utf-8'), smallPayload)
+  })
+})
+
+describe('It should use a synchronous method provided by a custom `zlib` :', async () => {
+  test('using `gzipSync`', async (t) => {
+    t.plan(3)
+
+    let usedCustom = false
+    const customZlib = {
+      gzipSync: (payload, options) => {
+        usedCustom = true
+        return zlib.gzipSync(payload, options)
+      }
+    }
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true, zlib: customZlib })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(usedCustom, true)
+    t.assert.equal(response.headers['content-encoding'], 'gzip')
+    t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), smallPayload)
+  })
+})
+
+describe('It should pass already compressed payloads through untouched :', async () => {
+  test('when the payload is already gzipped', async (t) => {
+    t.plan(3)
+
+    const gzipped = zlib.gzipSync(incompressiblePayload)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('application/octet-stream').send(gzipped)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.headers['content-encoding'], 'gzip')
+    t.assert.deepEqual(response.rawPayload, gzipped)
+    t.assert.deepEqual(zlib.gunzipSync(response.rawPayload), incompressiblePayload)
+  })
+
+  test('when the payload is already deflated', async (t) => {
+    t.plan(3)
+
+    const deflated = zlib.deflateSync(incompressiblePayload)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('application/octet-stream').send(deflated)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'deflate' }
+    })
+    t.assert.equal(response.headers['content-encoding'], 'deflate')
+    t.assert.deepEqual(response.rawPayload, deflated)
+    t.assert.deepEqual(zlib.inflateSync(response.rawPayload), incompressiblePayload)
+  })
+
+  test('when the payload is already gzipped using `reply.compress()`', async (t) => {
+    t.plan(2)
+
+    const gzipped = zlib.gzipSync(incompressiblePayload)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: false })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('application/octet-stream').compress(gzipped)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.headers['content-encoding'], 'gzip')
+    t.assert.deepEqual(response.rawPayload, gzipped)
+  })
+})
+
+describe('It should handle synchronous compression errors :', async () => {
+  test('using `onSend` hook', async (t) => {
+    t.plan(2)
+
+    const customZlib = {
+      gzipSync: () => {
+        throw new Error('sync compression failed')
+      }
+    }
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true, zlib: customZlib })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.statusCode, 500)
+    t.assert.equal(JSON.parse(response.payload).message, 'sync compression failed')
+  })
+
+  test('using `reply.compress()`', async (t) => {
+    t.plan(2)
+
+    const customZlib = {
+      gzipSync: () => {
+        throw new Error('sync compression failed')
+      }
+    }
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: false, zlib: customZlib })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').compress(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.statusCode, 500)
+    t.assert.equal(JSON.parse(response.payload).message, 'sync compression failed')
+  })
+})

--- a/test/sync-compress.test.js
+++ b/test/sync-compress.test.js
@@ -13,10 +13,14 @@ function buildPayload (size) {
   return 'the quick brown fox jumps over the lazy dog '.repeat(Math.ceil(size / 44)).slice(0, size)
 }
 
+// The default `syncThreshold` is derived from the host parallelism, so every test that
+// cares about which path a payload takes pins it explicitly to stay deterministic
+const syncThreshold = 32768
+
 const smallPayload = buildPayload(4096)
 const largePayload = buildPayload(200 * 1024)
 // incompressible, so that the already compressed payloads built from it stay
-// comfortably above the default `threshold` and below the default `syncThreshold`
+// comfortably above `threshold` and below the pinned `syncThreshold`
 const incompressiblePayload = randomBytes(4096)
 
 describe('When a buffered payload fits within `syncThreshold`, it should be compressed synchronously :', async () => {
@@ -24,7 +28,7 @@ describe('When a buffered payload fits within `syncThreshold`, it should be comp
     t.plan(4)
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true })
+    await fastify.register(compressPlugin, { global: true, syncThreshold })
 
     fastify.get('/', (_request, reply) => {
       reply.type('text/plain').send(smallPayload)
@@ -45,7 +49,7 @@ describe('When a buffered payload fits within `syncThreshold`, it should be comp
     t.plan(4)
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true })
+    await fastify.register(compressPlugin, { global: true, syncThreshold })
 
     fastify.get('/', (_request, reply) => {
       reply.type('text/plain').send(smallPayload)
@@ -66,7 +70,7 @@ describe('When a buffered payload fits within `syncThreshold`, it should be comp
     t.plan(4)
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true })
+    await fastify.register(compressPlugin, { global: true, syncThreshold })
 
     fastify.get('/', (_request, reply) => {
       reply.type('text/plain').send(smallPayload)
@@ -91,7 +95,7 @@ describe('When a buffered payload fits within `syncThreshold`, it should be comp
     t.plan(4)
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true })
+    await fastify.register(compressPlugin, { global: true, syncThreshold })
 
     fastify.get('/', (_request, reply) => {
       reply.type('text/plain').send(smallPayload)
@@ -112,7 +116,7 @@ describe('When a buffered payload fits within `syncThreshold`, it should be comp
     t.plan(3)
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true })
+    await fastify.register(compressPlugin, { global: true, syncThreshold })
 
     const buf = Buffer.from(smallPayload)
     fastify.get('/', (_request, reply) => {
@@ -133,7 +137,7 @@ describe('When a buffered payload fits within `syncThreshold`, it should be comp
     t.plan(4)
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: false })
+    await fastify.register(compressPlugin, { global: false, syncThreshold })
 
     fastify.get('/', (_request, reply) => {
       reply.type('text/plain').compress(smallPayload)
@@ -154,7 +158,7 @@ describe('When a buffered payload fits within `syncThreshold`, it should be comp
     t.plan(3)
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: false })
+    await fastify.register(compressPlugin, { global: false, syncThreshold })
 
     fastify.get('/', {
       compress: { syncThreshold: 8192 }
@@ -176,7 +180,7 @@ describe('When a buffered payload fits within `syncThreshold`, it should be comp
     t.plan(2)
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true, zlibOptions: { level: 9 } })
+    await fastify.register(compressPlugin, { global: true, syncThreshold, zlibOptions: { level: 9 } })
 
     fastify.get('/', (_request, reply) => {
       reply.type('text/plain').send(smallPayload)
@@ -197,7 +201,7 @@ describe('When a buffered payload fits within `syncThreshold`, it should be comp
     const brotliOptions = { params: { [zlib.constants.BROTLI_PARAM_QUALITY]: 11 } }
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true, brotliOptions })
+    await fastify.register(compressPlugin, { global: true, syncThreshold, brotliOptions })
 
     fastify.get('/', (_request, reply) => {
       reply.type('text/plain').send(smallPayload)
@@ -213,12 +217,104 @@ describe('When a buffered payload fits within `syncThreshold`, it should be comp
   })
 })
 
+describe('An explicit `syncThreshold` should always win over the computed default :', async () => {
+  // the computed default is clamped to [4096, 65536], so these two values sit on either
+  // side of every default the formula can produce, whatever the host reports
+  test('a value below the computed default should push a payload onto the stream pipeline', async (t) => {
+    t.plan(3)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true, syncThreshold: 2048 })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(smallPayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.headers['content-encoding'], 'gzip')
+    t.assert.ok(!response.headers['content-length'], 'no content length')
+    t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), smallPayload)
+  })
+
+  test('a value above the computed default should keep a payload on the synchronous path', async (t) => {
+    t.plan(3)
+
+    const hugePayload = buildPayload(128 * 1024)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true, syncThreshold: 256 * 1024 })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(hugePayload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.headers['content-encoding'], 'gzip')
+    t.assert.equal(response.headers['content-length'], response.rawPayload.length.toString())
+    t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), hugePayload)
+  })
+
+  test('the computed default should compress a payload it covers on every host', async (t) => {
+    t.plan(3)
+
+    // 2 KiB is above `threshold` and below the lowest default the formula can produce
+    const payload = buildPayload(2048)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(payload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.headers['content-encoding'], 'gzip')
+    t.assert.equal(response.headers['content-length'], response.rawPayload.length.toString())
+    t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), payload)
+  })
+
+  test('the computed default should stream a payload above the highest value it can produce', async (t) => {
+    t.plan(3)
+
+    // 256 KiB is above the upper clamp of the formula, so it streams on every host
+    const payload = buildPayload(256 * 1024)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { global: true })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send(payload)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.headers['content-encoding'], 'gzip')
+    t.assert.ok(!response.headers['content-length'], 'no content length')
+    t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), payload)
+  })
+})
+
 describe('It should fall back to the stream pipeline when the payload is not eligible :', async () => {
   test('when the payload is smaller than `threshold`', async (t) => {
     t.plan(3)
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true })
+    await fastify.register(compressPlugin, { global: true, syncThreshold })
 
     fastify.get('/', (_request, reply) => {
       reply.type('text/plain').send('hello world')
@@ -238,7 +334,7 @@ describe('It should fall back to the stream pipeline when the payload is not eli
     t.plan(4)
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true })
+    await fastify.register(compressPlugin, { global: true, syncThreshold })
 
     fastify.get('/', (_request, reply) => {
       reply.type('text/plain').send(largePayload)
@@ -301,7 +397,7 @@ describe('It should fall back to the stream pipeline when the payload is not eli
     t.plan(3)
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true })
+    await fastify.register(compressPlugin, { global: true, syncThreshold })
 
     fastify.get('/', (_request, reply) => {
       reply.type('text/plain').send(createReadStream('./package.json'))
@@ -321,7 +417,7 @@ describe('It should fall back to the stream pipeline when the payload is not eli
     t.plan(3)
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true })
+    await fastify.register(compressPlugin, { global: true, syncThreshold })
 
     fastify.get('/', (_request, reply) => {
       const stream = new ReadableStream({
@@ -350,7 +446,7 @@ describe('It should fall back to the stream pipeline when the payload is not eli
     const customZlib = { createGzip: () => (usedCustom = true) && zlib.createGzip() }
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true, zlib: customZlib })
+    await fastify.register(compressPlugin, { global: true, syncThreshold, zlib: customZlib })
 
     fastify.get('/', (_request, reply) => {
       reply.type('text/plain').send(smallPayload)
@@ -374,7 +470,7 @@ describe('It should fall back to the stream pipeline when the payload is not eli
     const customZlib = { createDeflate: () => (usedCustom = true) && zlib.createDeflate() }
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: false, zlib: customZlib })
+    await fastify.register(compressPlugin, { global: false, syncThreshold, zlib: customZlib })
 
     fastify.get('/', (_request, reply) => {
       reply.type('text/plain').compress(smallPayload)
@@ -394,7 +490,7 @@ describe('It should fall back to the stream pipeline when the payload is not eli
     t.plan(3)
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true, removeContentLengthHeader: false })
+    await fastify.register(compressPlugin, { global: true, syncThreshold, removeContentLengthHeader: false })
 
     fastify.get('/', (_request, reply) => {
       reply
@@ -508,7 +604,7 @@ describe('It should use a synchronous method provided by a custom `zlib` :', asy
     }
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true, zlib: customZlib })
+    await fastify.register(compressPlugin, { global: true, syncThreshold, zlib: customZlib })
 
     fastify.get('/', (_request, reply) => {
       reply.type('text/plain').send(smallPayload)
@@ -532,7 +628,7 @@ describe('It should pass already compressed payloads through untouched :', async
     const gzipped = zlib.gzipSync(incompressiblePayload)
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true })
+    await fastify.register(compressPlugin, { global: true, syncThreshold })
 
     fastify.get('/', (_request, reply) => {
       reply.type('application/octet-stream').send(gzipped)
@@ -554,7 +650,7 @@ describe('It should pass already compressed payloads through untouched :', async
     const deflated = zlib.deflateSync(incompressiblePayload)
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true })
+    await fastify.register(compressPlugin, { global: true, syncThreshold })
 
     fastify.get('/', (_request, reply) => {
       reply.type('application/octet-stream').send(deflated)
@@ -576,7 +672,7 @@ describe('It should pass already compressed payloads through untouched :', async
     const gzipped = zlib.gzipSync(incompressiblePayload)
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: false })
+    await fastify.register(compressPlugin, { global: false, syncThreshold })
 
     fastify.get('/', (_request, reply) => {
       reply.type('application/octet-stream').compress(gzipped)
@@ -603,7 +699,7 @@ describe('It should handle synchronous compression errors :', async () => {
     }
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: true, zlib: customZlib })
+    await fastify.register(compressPlugin, { global: true, syncThreshold, zlib: customZlib })
 
     fastify.get('/', (_request, reply) => {
       reply.type('text/plain').send(smallPayload)
@@ -628,7 +724,7 @@ describe('It should handle synchronous compression errors :', async () => {
     }
 
     const fastify = Fastify()
-    await fastify.register(compressPlugin, { global: false, zlib: customZlib })
+    await fastify.register(compressPlugin, { global: false, syncThreshold, zlib: customZlib })
 
     fastify.get('/', (_request, reply) => {
       reply.type('text/plain').compress(smallPayload)

--- a/test/utils.test.js
+++ b/test/utils.test.js
@@ -5,7 +5,41 @@ const { Socket } = require('node:net')
 const { Duplex, PassThrough, Readable, Stream, Transform, Writable } = require('node:stream')
 const { finished } = require('node:stream/promises')
 const { test } = require('node:test')
-const { isStream, isZstd, isDeflate, isGzip, intoAsyncIterator, createPeekTransform } = require('../lib/utils')
+const { availableParallelism } = require('node:os')
+const { computeSyncThreshold, isStream, isZstd, isDeflate, isGzip, intoAsyncIterator, createPeekTransform } = require('../lib/utils')
+
+test('computeSyncThreshold() utility should scale the default with the host parallelism', async (t) => {
+  t.plan(7)
+  const equal = t.assert.equal
+
+  // a single core has nothing to overlap stream compression with, so the whole range
+  // is worth compressing synchronously
+  equal(computeSyncThreshold(1), 65536)
+  equal(computeSyncThreshold(2), 8192)
+  // from three cores up the lower clamp takes over
+  equal(computeSyncThreshold(3), 4096)
+  equal(computeSyncThreshold(4), 4096)
+  // beyond libuv's threadpool size extra cores cannot compress any more in parallel
+  equal(computeSyncThreshold(8), 4096)
+  equal(computeSyncThreshold(16), 4096)
+  equal(computeSyncThreshold(1024), 4096)
+})
+
+test('computeSyncThreshold() utility should clamp the default to a sane range', async (t) => {
+  const parallelisms = [0, 1, 2, 3, 4, 7, 12, 64, 4096]
+  t.plan(parallelisms.length)
+
+  for (const parallelism of parallelisms) {
+    const threshold = computeSyncThreshold(parallelism)
+    t.assert.ok(threshold >= 4096 && threshold <= 65536, `${parallelism} cores yielded ${threshold}`)
+  }
+})
+
+test('computeSyncThreshold() utility should default to the host parallelism', async (t) => {
+  t.plan(1)
+
+  t.assert.equal(computeSyncThreshold(), computeSyncThreshold(availableParallelism()))
+})
 
 test('isStream() utility should be able to detect Streams', async (t) => {
   t.plan(12)

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -37,6 +37,7 @@ type RouteCompressOptions = Pick<fastifyCompress.FastifyCompressOptions,
   | 'inflateIfDeflated'
   | 'onUnsupportedEncoding'
   | 'removeContentLengthHeader'
+  | 'syncThreshold'
   | 'threshold'
   | 'zlib'
   | 'zlibOptions'
@@ -78,6 +79,7 @@ declare namespace fastifyCompress {
     onUnsupportedRequestEncoding?: (encoding: string, request: FastifyRequest, reply: FastifyReply) => Error | undefined | null;
     removeContentLengthHeader?: boolean;
     requestEncodings?: EncodingToken[];
+    syncThreshold?: number;
     threshold?: number;
     zlib?: unknown;
     zlibOptions?: ZlibOptions;

--- a/types/index.tst.ts
+++ b/types/index.tst.ts
@@ -9,6 +9,7 @@ const stream = createReadStream('./package.json')
 const withGlobalOptions: FastifyCompressOptions = {
   global: true,
   threshold: 10,
+  syncThreshold: 32768,
   zlib,
   brotliOptions: {
     params: {
@@ -55,7 +56,8 @@ appWithoutGlobal.get('/one', {
     zlib: {
       createGzip: () => zlib.createGzip()
     },
-    removeContentLengthHeader: false
+    removeContentLengthHeader: false,
+    syncThreshold: 0
   },
   decompress: {
     forceRequestEncoding: 'gzip',


### PR DESCRIPTION
Two related compression performance changes, plus a benchmark to measure them.

## 1. Apply the recommended brotli quality default regardless of `global`

`processCompressParams()` only applied `recommendedDefaultBrotliOptions` (`BROTLI_PARAM_QUALITY: 4`) when `params.global` was true. Registering with `{ global: false }` — the documented manual mode where routes call `reply.compress(payload)` — left `brotliOptions` undefined, so zlib's default quality of **11** was used instead.

The README documents this default as 4, and the constant's own comment notes that quality 11 "has a heavy impact on performance", so this was simply the wrong default rather than an intentional difference.

Compressing 1 MiB with `Accept-Encoding: br` via `reply.compress()`:

| | before | after |
|---|---|---|
| `{ global: true }` | 9 ms | 9 ms |
| `{ global: false }` | **1206 ms** | **9 ms** |

Merge order is unchanged, so a user-supplied `brotliOptions` still takes precedence.

## 2. Compress small buffered payloads synchronously

Every compressed response currently goes through a stream pipeline. For a payload that is already fully in memory, that means allocating a peek transform and a zlib stream per response, and handing the work to the libuv threadpool in several round trips.

For small payloads that costs more than it saves. This adds a `syncThreshold` option: string and Buffer payloads at or below it are compressed in one call, and everything else — larger payloads, streams, web streams, `Response` bodies — keeps the existing pipeline untouched.

Measured over real sockets, 50 concurrent connections, gzip level 6, ~8:1 payloads:

| payload | streamed | synchronous | change |
|---|---|---|---|
| 1 KiB | 17985 r/s | 38909 r/s | **+116%** |
| 2 KiB | 20779 r/s | 30294 r/s | **+46%** |

There is also a memory effect that is independent of payload size, because the synchronous path allocates no per-response zlib context and releases the source buffer immediately instead of pinning it for as long as the response is in flight. Under the same load, RSS dropped from ~348 MiB to ~166 MiB.

### The default scales with host parallelism

The stream path only pays off when there are spare cores to overlap the threadpool work with, so the crossover point depends on how many are available. `syncThreshold` therefore defaults to:

| cores | 1 | 2 | 3+ |
|---|---|---|---|
| default | 65536 | 8192 | 4096 |

Computed once at registration from `availableParallelism()`, clamped to `[4096, 65536]`. libuv's threadpool defaults to 4 threads, so the effect saturates there and the formula does not rely on `UV_THREADPOOL_SIZE` being tuned.

Since libuv 1.49 (Node.js 22.12) `availableParallelism()` accounts for a cgroup CPU quota, so a container given whole cores reports those rather than the host's and gets an appropriate default on its own. Two cases still read as a wide host and land on the smallest default: Node.js before 22.12, which does not consult the quota at all, and a quota below one full core such as Kubernetes `cpu: 500m`, which floors to zero and falls back to the host count. Both err towards the small end, which is the safe direction — settling too low only forgoes some of the win, while settling too high costs considerably more than it gains — and such deployments should set `syncThreshold` explicitly. Quotas are floored rather than rounded, so `cpu: 2500m` reports two cores. This is documented in the README.

Setting `syncThreshold: 0` disables the path entirely and restores the current behaviour exactly.

### Behaviour change

Compressed responses at or below the threshold now carry an accurate `Content-Length` instead of being chunked. The compressed size is known on this path, so there is no stale value to remove — `removeContentLengthHeader` exists because the streaming path cannot know it. When `removeContentLengthHeader: false` and the reply already carries a `Content-Length`, the synchronous path is skipped so the caller-supplied value is preserved byte for byte.

## 3. `npm run benchmark`

Both configurations run against the same build, so no second checkout is needed. The harness is shaped around the ways this measurement goes wrong: the server runs in a forked process, since compressing synchronously occupies the event loop and a co-located client would measure itself; load is driven over real sockets with real concurrency, because `inject()` has neither and cannot observe the stream path overlapping with other cores; and every size is measured repeatedly with medians reported.

It also includes a payload above the threshold as a control. Both configurations stream it, so its result must come out near zero — when it does not, the machine was too noisy and the run is rejected rather than reported. It warns when the load average is high for the same reason.

The numbers above were taken on a shared development machine and the wins at 1–2 KiB are larger than I would quote with confidence; please re-run on an idle host. The memory figures are low-variance and the direction is consistent across every run.

## Notes for reviewers

Two pre-existing issues found while working on this, both left alone as out of scope:

- The `brotliOptions` merge is shallow, so passing any other brotli param still drops the quality default — on `global: true` too. The documented default only holds when no `brotliOptions` are passed at all.
- `Object.assign({}, globalCompressParams, routeParams)` means any route-level `compress` object silently discards globally configured `brotliOptions`. Reproducible on `main`.

`test/regression/issue-350.test.js` is pinned to `syncThreshold: 0`: its ~57 KiB payload sits inside the clamp range, so on a single-core host it would have taken the synchronous path and quietly stopped exercising the streaming premature-close bug it was written for, while still passing.

226 tests pass (188 on `main`), lint and tstyche clean, c8 at 100%. The suite was verified deterministic with `availableParallelism()` stubbed at 1, 2, 3 and 64 cores.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C75AXneqmj5b9DKKHLvkRt

