### PR TITLE
fix: preserve status and headers when compressing a Fetch Response

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const {
   isWebReadableStream,
   isFetchResponse,
   webStreamToNodeReadable,
+  unwrapFetchResponse,
   createPeekTransform
 } = require('./lib/utils')
 
@@ -296,7 +297,7 @@ function buildRouteCompress (_fastify, params, routeOptions, decorateOnly) {
 
     if (typeof payload.pipe !== 'function') {
       if (isFetchResponse(payload)) {
-        payload = payload.body
+        payload = unwrapFetchResponse(reply, payload)
       }
 
       if (isWebReadableStream(payload)) {
@@ -425,7 +426,7 @@ function compress (params) {
 
     if (typeof payload.pipe !== 'function') {
       if (isFetchResponse(payload)) {
-        payload = payload.body
+        payload = unwrapFetchResponse(this, payload)
       }
 
       if (isWebReadableStream(payload)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,6 +64,14 @@ function webStreamToNodeReadable (webStream) {
   return NodeReadable.fromWeb(webStream)
 }
 
+function unwrapFetchResponse (reply, response) {
+  reply.code(response.status)
+  for (const [name, value] of response.headers) {
+    reply.header(name, value)
+  }
+  return response.body
+}
+
 /**
  * Provide a async iteratable for Readable.from
  */
@@ -192,5 +200,6 @@ module.exports = {
   isWebReadableStream,
   isFetchResponse,
   webStreamToNodeReadable,
+  unwrapFetchResponse,
   createPeekTransform
 }

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -288,6 +288,36 @@ describe('When `global` is not set, it is `true` by default :', async () => {
     t.assert.equal(payload.toString('utf-8'), body)
   })
 
+  test('it should preserve a Fetch API Response status and headers', async (t) => {
+    t.plan(5)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { threshold: 0 })
+
+    const body = 'hello from fetch response'
+    fastify.get('/fetch-resp', (_request, reply) => {
+      reply.send(new Response(body, {
+        status: 201,
+        headers: {
+          'content-type': 'text/plain',
+          'cache-control': 'public, max-age=120',
+          'set-cookie': 'a=b; HttpOnly'
+        }
+      }))
+    })
+
+    const response = await fastify.inject({
+      url: '/fetch-resp',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.statusCode, 201)
+    t.assert.equal(response.headers['content-type'], 'text/plain')
+    t.assert.equal(response.headers['cache-control'], 'public, max-age=120')
+    t.assert.equal(response.headers['set-cookie'], 'a=b; HttpOnly')
+    t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), body)
+  })
+
   test('it should compress a Web ReadableStream body', async (t) => {
     t.plan(1)
 

--- a/test/routes-compress.test.js
+++ b/test/routes-compress.test.js
@@ -364,6 +364,23 @@ test('reply.compress should handle Fetch Response', async (t) => {
   t.assert.equal(zlib.gunzipSync(res.rawPayload).toString('utf8'), 'from reply.compress')
 })
 
+test('reply.compress should preserve a Fetch Response status and headers', async (t) => {
+  t.plan(4)
+  const fastify = Fastify()
+  await fastify.register(compressPlugin, { global: true, threshold: 0 })
+  fastify.get('/', (_req, reply) => {
+    reply.compress(new Response('from reply.compress', {
+      status: 418,
+      headers: { 'content-type': 'text/plain', 'x-custom': 'kept' }
+    }))
+  })
+  const res = await fastify.inject({ url: '/', method: 'GET', headers: { 'accept-encoding': 'gzip' } })
+  t.assert.equal(res.statusCode, 418)
+  t.assert.equal(res.headers['content-type'], 'text/plain')
+  t.assert.equal(res.headers['x-custom'], 'kept')
+  t.assert.equal(zlib.gunzipSync(res.rawPayload).toString('utf8'), 'from reply.compress')
+})
+
 test('reply.compress should handle Web ReadableStream', async (t) => {
   t.plan(1)
   const fastify = Fastify()


### PR DESCRIPTION
Compressing a Fetch `Response` drops its status code and headers.

Fastify doesn't unwrap a `Response` before `onSend` - it does that afterwards in `onSendEnd` and
only if the payload is still a `Response`. We swap in the compressed stream before then, so that
never runs and `reply.code()`/`reply.header()` are never called. 

Practically this means `content-type`, `Cache-Control` and `Set-Cookie` disappear and every status
becomes 200.

```js
app.register(compress, { threshold: 0 })
app.get('/', (_req, reply) =>
  reply.send(new Response('hello', { status: 401, headers: { 'set-cookie': 'a=b' } })))
```

```
accept-encoding: gzip      -> 200, no set-cookie
accept-encoding: identity  -> 401, set-cookie: a=b
```

Fix applies the status and headers when we take the body, same as `onSendEnd` would have.

This affects every tRPC v11 app using this plugin, since its Fastify adapter always sends a
`Response`, and those are streams so the threshold never skips them. 
Related issue: trpc/trpc#6628.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [x] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)