### PR TITLE
fix: unwrap fetch response before noCompress check for SSE support

### DIFF
--- a/index.js
+++ b/index.js
@@ -329,14 +329,18 @@ function buildRouteCompress (_fastify, params, routeOptions, decorateOnly) {
   }
 
   function onSend (req, reply, payload, next) {
+    if (isFetchResponse(payload)) {
+      payload = unwrapFetchResponse(reply, payload)
+    }
+
     if (payload == null) {
-      return next()
+      return next(null, payload)
     }
 
     const responseEncoding = reply.getHeader('Content-Encoding')
     if (responseEncoding && responseEncoding !== 'identity') {
       // response is already compressed
-      return next()
+      return next(null, payload)
     }
 
     let stream, encoding
@@ -372,10 +376,6 @@ function buildRouteCompress (_fastify, params, routeOptions, decorateOnly) {
     }
 
     if (typeof payload.pipe !== 'function') {
-      if (isFetchResponse(payload)) {
-        payload = unwrapFetchResponse(reply, payload)
-      }
-
       if (isWebReadableStream(payload)) {
         payload = webStreamToNodeReadable(payload)
       } else {
@@ -487,6 +487,14 @@ function compress (params) {
       return
     }
 
+    if (isFetchResponse(payload)) {
+      if (payload.body === null) {
+        return this.send(payload)
+      }
+
+      payload = unwrapFetchResponse(this, payload)
+    }
+
     let stream, encoding
     const noCompress =
       // don't compress on x-no-compression header
@@ -519,10 +527,6 @@ function compress (params) {
     }
 
     if (typeof payload.pipe !== 'function') {
-      if (isFetchResponse(payload)) {
-        payload = unwrapFetchResponse(this, payload)
-      }
-
       if (isWebReadableStream(payload)) {
         payload = webStreamToNodeReadable(payload)
       } else if (!Buffer.isBuffer(payload) && typeof payload !== 'string') {

--- a/index.js
+++ b/index.js
@@ -18,6 +18,7 @@ const {
   isWebReadableStream,
   isFetchResponse,
   webStreamToNodeReadable,
+  unwrapFetchResponse,
   createPeekTransform
 } = require('./lib/utils')
 
@@ -296,7 +297,7 @@ function buildRouteCompress (_fastify, params, routeOptions, decorateOnly) {
 
     if (typeof payload.pipe !== 'function') {
       if (isFetchResponse(payload)) {
-        payload = payload.body
+        payload = unwrapFetchResponse(reply, payload)
       }
 
       if (isWebReadableStream(payload)) {
@@ -425,7 +426,7 @@ function compress (params) {
 
     if (typeof payload.pipe !== 'function') {
       if (isFetchResponse(payload)) {
-        payload = payload.body
+        payload = unwrapFetchResponse(this, payload)
       }
 
       if (isWebReadableStream(payload)) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,6 +64,14 @@ function webStreamToNodeReadable (webStream) {
   return NodeReadable.fromWeb(webStream)
 }
 
+function unwrapFetchResponse (reply, response) {
+  reply.code(response.status)
+  for (const [name, value] of response.headers) {
+    reply.header(name, value)
+  }
+  return response.body
+}
+
 /**
  * Provide a async iteratable for Readable.from
  */
@@ -192,5 +200,6 @@ module.exports = {
   isWebReadableStream,
   isFetchResponse,
   webStreamToNodeReadable,
+  unwrapFetchResponse,
   createPeekTransform
 }

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -318,6 +318,98 @@ describe('When `global` is not set, it is `true` by default :', async () => {
     t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), body)
   })
 
+  test('it should not compress a Fetch API Response holding a non-compressible `Content-Type`', async (t) => {
+    t.plan(2)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { threshold: 0 })
+
+    const body = 'data: hello from fetch response\n\n'
+    fastify.get('/fetch-resp', (_request, reply) => {
+      reply.send(new Response(body, { headers: { 'content-type': 'text/event-stream' } }))
+    })
+
+    const response = await fastify.inject({
+      url: '/fetch-resp',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.headers['content-encoding'], undefined)
+    t.assert.equal(response.rawPayload.toString('utf-8'), body)
+  })
+
+  test('it should not compress a Fetch API Response that is already compressed', async (t) => {
+    t.plan(2)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { threshold: 0 })
+
+    const body = 'hello from fetch response'
+    fastify.get('/fetch-resp', (_request, reply) => {
+      reply.send(new Response(zlib.brotliCompressSync(body), {
+        headers: {
+          'content-type': 'text/plain',
+          'content-encoding': 'br'
+        }
+      }))
+    })
+
+    const response = await fastify.inject({
+      url: '/fetch-resp',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.headers['content-encoding'], 'br')
+    t.assert.equal(zlib.brotliDecompressSync(response.rawPayload).toString('utf-8'), body)
+  })
+
+  test('it should not compress a partial Fetch API Response', async (t) => {
+    t.plan(3)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { threshold: 0 })
+
+    const body = 'hello fr'
+    fastify.get('/fetch-resp', (_request, reply) => {
+      reply.send(new Response(body, {
+        status: 206,
+        headers: {
+          'content-type': 'text/plain',
+          'content-range': 'bytes 0-7/25'
+        }
+      }))
+    })
+
+    const response = await fastify.inject({
+      url: '/fetch-resp',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.statusCode, 206)
+    t.assert.equal(response.headers['content-encoding'], undefined)
+    t.assert.equal(response.rawPayload.toString('utf-8'), body)
+  })
+
+  test('it should send a bodyless Fetch API Response as is', async (t) => {
+    t.plan(3)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { threshold: 0 })
+
+    fastify.get('/fetch-resp', (_request, reply) => {
+      reply.send(new Response(null, { status: 204, headers: { 'x-custom': 'kept' } }))
+    })
+
+    const response = await fastify.inject({
+      url: '/fetch-resp',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.statusCode, 204)
+    t.assert.equal(response.headers['x-custom'], 'kept')
+    t.assert.equal(response.rawPayload.length, 0)
+  })
+
   test('it should compress a Web ReadableStream body', async (t) => {
     t.plan(1)
 

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -288,6 +288,36 @@ describe('When `global` is not set, it is `true` by default :', async () => {
     t.assert.equal(payload.toString('utf-8'), body)
   })
 
+  test('it should preserve a Fetch API Response status and headers', async (t) => {
+    t.plan(5)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, { threshold: 0 })
+
+    const body = 'hello from fetch response'
+    fastify.get('/fetch-resp', (_request, reply) => {
+      reply.send(new Response(body, {
+        status: 201,
+        headers: {
+          'content-type': 'text/plain',
+          'cache-control': 'public, max-age=120',
+          'set-cookie': 'a=b; HttpOnly'
+        }
+      }))
+    })
+
+    const response = await fastify.inject({
+      url: '/fetch-resp',
+      method: 'GET',
+      headers: { 'accept-encoding': 'gzip' }
+    })
+    t.assert.equal(response.statusCode, 201)
+    t.assert.equal(response.headers['content-type'], 'text/plain')
+    t.assert.equal(response.headers['cache-control'], 'public, max-age=120')
+    t.assert.equal(response.headers['set-cookie'], 'a=b; HttpOnly')
+    t.assert.equal(zlib.gunzipSync(response.rawPayload).toString('utf-8'), body)
+  })
+
   test('it should compress a Web ReadableStream body', async (t) => {
     t.plan(1)
 

--- a/test/routes-compress.test.js
+++ b/test/routes-compress.test.js
@@ -381,6 +381,32 @@ test('reply.compress should preserve a Fetch Response status and headers', async
   t.assert.equal(zlib.gunzipSync(res.rawPayload).toString('utf8'), 'from reply.compress')
 })
 
+test('reply.compress should not compress a Fetch Response holding a non-compressible `Content-Type`', async (t) => {
+  t.plan(2)
+  const fastify = Fastify()
+  await fastify.register(compressPlugin, { global: true, threshold: 0 })
+  fastify.get('/', (_req, reply) => {
+    reply.compress(new Response('data: from reply.compress\n\n', {
+      headers: { 'content-type': 'text/event-stream' }
+    }))
+  })
+  const res = await fastify.inject({ url: '/', method: 'GET', headers: { 'accept-encoding': 'gzip' } })
+  t.assert.equal(res.headers['content-encoding'], undefined)
+  t.assert.equal(res.rawPayload.toString('utf8'), 'data: from reply.compress\n\n')
+})
+
+test('reply.compress should send a bodyless Fetch Response as is', async (t) => {
+  t.plan(2)
+  const fastify = Fastify()
+  await fastify.register(compressPlugin, { global: true, threshold: 0 })
+  fastify.get('/', (_req, reply) => {
+    reply.compress(new Response(null, { status: 204 }))
+  })
+  const res = await fastify.inject({ url: '/', method: 'GET', headers: { 'accept-encoding': 'gzip' } })
+  t.assert.equal(res.statusCode, 204)
+  t.assert.equal(res.rawPayload.length, 0)
+})
+
 test('reply.compress should handle Web ReadableStream', async (t) => {
   t.plan(1)
   const fastify = Fastify()

--- a/test/routes-compress.test.js
+++ b/test/routes-compress.test.js
@@ -364,6 +364,23 @@ test('reply.compress should handle Fetch Response', async (t) => {
   t.assert.equal(zlib.gunzipSync(res.rawPayload).toString('utf8'), 'from reply.compress')
 })
 
+test('reply.compress should preserve a Fetch Response status and headers', async (t) => {
+  t.plan(4)
+  const fastify = Fastify()
+  await fastify.register(compressPlugin, { global: true, threshold: 0 })
+  fastify.get('/', (_req, reply) => {
+    reply.compress(new Response('from reply.compress', {
+      status: 418,
+      headers: { 'content-type': 'text/plain', 'x-custom': 'kept' }
+    }))
+  })
+  const res = await fastify.inject({ url: '/', method: 'GET', headers: { 'accept-encoding': 'gzip' } })
+  t.assert.equal(res.statusCode, 418)
+  t.assert.equal(res.headers['content-type'], 'text/plain')
+  t.assert.equal(res.headers['x-custom'], 'kept')
+  t.assert.equal(zlib.gunzipSync(res.rawPayload).toString('utf8'), 'from reply.compress')
+})
+
 test('reply.compress should handle Web ReadableStream', async (t) => {
   t.plan(1)
   const fastify = Fastify()


### PR DESCRIPTION
onSend decides whether to compress by reading the reply, but when the payload is a Fetch Response fastify only copies its status and headers onto the reply after all onSend hooks have run. The checks therefore see no Content-Type, no Content-Encoding, no Content-Range and a stale status code.

The most visible effect is that the text/event-stream exclusion from #133 never fires for a Response, which is how the tRPC fastify adapter replies. SSE gets compressed and then buffered by zlib until the stream ends, so subscription events all arrive at once. It also hits already-encoded responses (relabelled with the wrong encoding), 206 with Content-Range, and a bodyless Response, which currently 500s on Buffer.byteLength(null).

Regression from #374; #420 fixed the lost headers but kept the ordering.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
