### PR TITLE
docs(readme): complete Past sponsors: label in Acknowledgments section

### DIFF
--- a/README.md
+++ b/README.md
@@ -480,7 +480,7 @@ await fastify.register(
 
 ## Acknowledgments
 
-Past sp
+Past sponsors:
 - LetzDoIt
 
 ## License


### PR DESCRIPTION
Proposal:

- Fixes truncated "Past sp" text in "Past sponsors:" in the Acknowledgments section of the README.