### PR TITLE
fix: negotiate encoding before compression checks

### DIFF
--- a/index.js
+++ b/index.js
@@ -343,7 +343,8 @@ function buildRouteCompress (_fastify, params, routeOptions, decorateOnly) {
       return next(null, payload)
     }
 
-    let stream, encoding
+    let stream
+    const encoding = getEncodingHeader(params.encodings, req)
     const noCompress =
       // don't compress on x-no-compression header
       (req.headers['x-no-compression'] !== undefined) ||
@@ -353,7 +354,7 @@ function buildRouteCompress (_fastify, params, routeOptions, decorateOnly) {
       // don't compress if not one of the indicated compressible types
       (shouldCompress(reply.getHeader('Content-Type') || 'application/json', params.compressibleTypes) === false) ||
       // don't compress on missing or identity `accept-encoding` header
-      ((encoding = getEncodingHeader(params.encodings, req)) == null || encoding === 'identity')
+      (encoding == null || encoding === 'identity')
 
     if (encoding == null && params.onUnsupportedEncoding != null) {
       const encodingHeader = req.headers['accept-encoding']
@@ -495,14 +496,15 @@ function compress (params) {
       payload = unwrapFetchResponse(this, payload)
     }
 
-    let stream, encoding
+    let stream
+    const encoding = getEncodingHeader(params.encodings, this.request)
     const noCompress =
       // don't compress on x-no-compression header
       (this.request.headers['x-no-compression'] !== undefined) ||
       // don't compress if not one of the indicated compressible types
       (shouldCompress(this.getHeader('Content-Type') || 'application/json', params.compressibleTypes) === false) ||
       // don't compress on missing or identity `accept-encoding` header
-      ((encoding = getEncodingHeader(params.encodings, this.request)) == null || encoding === 'identity')
+      (encoding == null || encoding === 'identity')
 
     if (encoding == null && params.onUnsupportedEncoding != null) {
       const encodingHeader = this.request.headers['accept-encoding']

--- a/test/global-compress.test.js
+++ b/test/global-compress.test.js
@@ -2592,6 +2592,38 @@ describe('It should add hooks correctly: ', async () => {
 })
 
 describe('When `Accept-Encoding` request header values are not supported and `onUnsupportedEncoding` is defined :', async () => {
+  test('it should not call `onUnsupportedEncoding()` when x-no-compression skips a supported encoding', async (t) => {
+    t.plan(4)
+
+    let unsupportedCalls = 0
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, {
+      global: true,
+      onUnsupportedEncoding: (encoding, _request, reply) => {
+        unsupportedCalls++
+        reply.code(406)
+        return JSON.stringify({ hello: encoding })
+      }
+    })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('text/plain').send('hello')
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      headers: {
+        'accept-encoding': 'gzip',
+        'x-no-compression': 'true'
+      }
+    })
+
+    t.assert.equal(response.statusCode, 200)
+    t.assert.equal(response.payload, 'hello')
+    t.assert.ok(!response.headers['content-encoding'])
+    t.assert.equal(unsupportedCalls, 0)
+  })
+
   test('it should call the defined `onUnsupportedEncoding()` method', async (t) => {
     t.plan(2)
 
@@ -3471,6 +3503,37 @@ describe('It should uncompress data when `Accept-Encoding` request header is mis
 })
 
 describe('When `onUnsupportedEncoding` is set and the `Accept-Encoding` request header value is an unsupported encoding', async () => {
+  test('it should not call `onUnsupportedEncoding()` when content type skips a supported encoding', async (t) => {
+    t.plan(4)
+
+    let unsupportedCalls = 0
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, {
+      global: true,
+      onUnsupportedEncoding: (encoding, _request, reply) => {
+        unsupportedCalls++
+        reply.code(406)
+        return JSON.stringify({ hello: encoding })
+      }
+    })
+
+    fastify.get('/', (_request, reply) => {
+      reply.type('image/png').compress(Buffer.from('hello'))
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      headers: {
+        'accept-encoding': 'gzip'
+      }
+    })
+
+    t.assert.equal(response.statusCode, 200)
+    t.assert.equal(response.rawPayload.toString(), 'hello')
+    t.assert.ok(!response.headers['content-encoding'])
+    t.assert.equal(unsupportedCalls, 0)
+  })
+
   test('it should call the defined `onUnsupportedEncoding()` method', async (t) => {
     t.plan(3)
 


### PR DESCRIPTION
Fixes #305.

The compression paths currently negotiate `Accept-Encoding` inside the last operand of a short-circuiting `noCompress` expression. When `x-no-compression` or a non-compressible content type matches first, `encoding` remains undefined and a configured `onUnsupportedEncoding` handler is called even for a supported encoding.

This change negotiates the encoding before evaluating the skip conditions in both the global `onSend` hook and `reply.compress()` paths. It adds regression coverage for each path and verifies that the response is passed through without invoking the unsupported-encoding handler.

This supersedes the voluntarily closed draft #404 and is rebased on current `main`.

Validation:
- `npm run lint`
- `npm test` — 236 unit tests and 10 type assertions passed
- `git diff --check`
- `npm run benchmark --if-present` completed all measurements, but its unchanged 8 KiB streaming control varied by 25% and exceeded the 10% noise tolerance; the benchmark reports this as machine noise and recommends rerunning on an idle machine before drawing conclusions

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer’s Certificate of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of Conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)