### PR TITLE
test: exclude benchmarks from coverage

### DIFF
--- a/.c8rc
+++ b/.c8rc
@@ -1,6 +1,6 @@
 {
   "all": true,
-  "exclude": ["test/", "coverage/", "types/", "eslint.config.js"],
+  "exclude": ["test/", "coverage/", "types/", "benchmark/", "eslint.config.js"],
   "clean": true,
   "check-coverage": true,
   "branches": 100,


### PR DESCRIPTION
## Summary

- exclude benchmark scripts from the production coverage inventory
- keep 100% coverage enforcement focused on runtime source files
- preserve the existing strict C8 thresholds

## Testing

- npm run test:coverage
- npm run test:typescript
- npm run lint