### PR TITLE
fix: preserve global decompress options

### DIFF
--- a/index.js
+++ b/index.js
@@ -91,9 +91,10 @@ function fastifyCompress (fastify, opts, next) {
     if (routeOptions.decompress !== undefined) {
       if (typeof routeOptions.decompress === 'object') {
         // if the current endpoint has a custom compress configuration ...
-        const mergedDecompressParams = Object.assign(
-          {}, globalDecompressParams, processDecompressParams(routeOptions.decompress)
-        )
+        const mergedDecompressParams = processDecompressParams({
+          ...globalDecompressParams,
+          ...routeOptions.decompress
+        })
 
         buildRouteDecompress(fastify, mergedDecompressParams, routeOptions)
       } else if (routeOptions.decompress === false) {

--- a/test/routes-decompress.test.js
+++ b/test/routes-decompress.test.js
@@ -188,6 +188,137 @@ describe('When using routes `decompress` settings :', async () => {
     t.assert.match(response.json().message, /is not valid JSON/)
   })
 
+  test('it should preserve global onInvalidRequestPayload when route decompress options are provided', async (t) => {
+    t.plan(2)
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, {
+      onInvalidRequestPayload (encoding, _request, error) {
+        return {
+          statusCode: 400,
+          code: 'GLOBAL_HANDLER',
+          message: `Global Handler: ${encoding} - ${error.message}`
+        }
+      }
+    })
+
+    fastify.post('/custom', {
+      decompress: {
+        requestEncodings: ['deflate']
+      }
+    }, (request, reply) => {
+      reply.send(request.body.name)
+    })
+
+    const response = await fastify.inject({
+      url: '/custom',
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-encoding': 'deflate'
+      },
+      payload: createPayload(zlib.createGzip)
+    })
+    t.assert.equal(response.statusCode, 400)
+    t.assert.equal(response.json().code, 'GLOBAL_HANDLER')
+  })
+
+  test('it should preserve global onUnsupportedRequestEncoding when route decompress options are provided', async (t) => {
+    t.plan(2)
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, {
+      onUnsupportedRequestEncoding (encoding) {
+        return {
+          statusCode: 400,
+          code: 'GLOBAL_UNSUPPORTED',
+          message: `Unsupported: ${encoding}`
+        }
+      }
+    })
+    fastify.post('/custom', {
+      decompress: {
+        requestEncodings: ['gzip']
+      }
+    }, (request, reply) => {
+      reply.send(request.body.name)
+    })
+    const response = await fastify.inject({
+      url: '/custom',
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-encoding': 'br'
+      },
+      payload: createPayload(zlib.createBrotliCompress)
+    })
+
+    t.assert.equal(response.statusCode, 400)
+    t.assert.equal(response.json().code, 'GLOBAL_UNSUPPORTED')
+  })
+
+  test('it should allow route onInvalidRequestPayload to override global handler', async (t) => {
+    t.plan(2)
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, {
+      onInvalidRequestPayload () {
+        return {
+          statusCode: 400,
+          code: 'GLOBAL_HANDLER'
+        }
+      }
+    })
+    fastify.post('/custom', {
+      decompress: {
+        requestEncodings: ['deflate'],
+        onInvalidRequestPayload (encoding, _request, error) {
+          return {
+            statusCode: 400,
+            code: 'ROUTE_HANDLER',
+            message: `${encoding}: ${error.message}`
+          }
+        }
+      }
+    }, (request, reply) => {
+      reply.send(request.body.name)
+    })
+    const response = await fastify.inject({
+      url: '/custom',
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-encoding': 'deflate'
+      },
+      payload: createPayload(zlib.createGzip)
+    })
+    t.assert.equal(response.statusCode, 400)
+    t.assert.equal(response.json().code, 'ROUTE_HANDLER')
+  })
+
+  test('it should allow route decompress options to override global options', async (t) => {
+    t.plan(2)
+    const fastify = Fastify()
+    await fastify.register(compressPlugin, {
+      requestEncodings: ['gzip']
+    })
+    fastify.post('/custom', {
+      decompress: {
+        requestEncodings: ['deflate']
+      }
+    }, (request, reply) => {
+      reply.send(request.body.name)
+    })
+    const response = await fastify.inject({
+      url: '/custom',
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-encoding': 'deflate'
+      },
+      payload: createPayload(zlib.createDeflate)
+    })
+    t.assert.equal(response.statusCode, 200)
+    t.assert.equal(response.body, '@fastify/compress')
+  })
+
   test('it should return FST_ERR_CTP_INVALID_CONTENT_LENGTH when Content-Length mismatches payload', async (t) => {
     t.plan(2)
     const equal = t.assert.equal


### PR DESCRIPTION
### Description

When route-level `decompress` options were provided, global decompression callbacks such as `onInvalidRequestPayload` and `onUnsupportedRequestEncoding` were not preserved.

This change merges the global and route-level decompression options before processing them.

The added tests verify that:
- Global decompression handlers are preserved when route-level options are provided.
- Route-level handlers override global handlers.
- Route-level decompression options override the corresponding global options.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)
      and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)

Fixes: #340
