### PR TITLE
fix: accept mixed-case Content-Encoding values

### DIFF
--- a/index.js
+++ b/index.js
@@ -432,6 +432,9 @@ function buildRouteDecompress (_fastify, params, routeOptions) {
 
     if (!encoding) {
       encoding = request.headers['content-encoding']
+      if (typeof encoding === 'string') {
+        encoding = encoding.toLowerCase()
+      }
     }
 
     // The request is not compressed, nothing to do here

--- a/index.js
+++ b/index.js
@@ -429,9 +429,11 @@ function buildRouteDecompress (_fastify, params, routeOptions) {
   function preParsing (request, _reply, raw, next) {
     // Get the encoding from the options or from the headers
     let encoding = params.forceEncoding
+    let rawEncoding = encoding
 
     if (!encoding) {
       encoding = request.headers['content-encoding']
+      rawEncoding = encoding
       if (typeof encoding === 'string') {
         encoding = encoding.toLowerCase()
       }
@@ -448,14 +450,14 @@ function buildRouteDecompress (_fastify, params, routeOptions) {
 
       if (params.onUnsupportedRequestEncoding) {
         try {
-          errorPayload = params.onUnsupportedRequestEncoding(encoding, request)
+          errorPayload = params.onUnsupportedRequestEncoding(rawEncoding, request)
         } catch {
           errorPayload = undefined
         }
       }
 
       if (!errorPayload) {
-        errorPayload = new InvalidRequestEncodingError(encoding)
+        errorPayload = new InvalidRequestEncodingError(rawEncoding)
       }
 
       return next(errorPayload)

--- a/test/global-decompress.test.js
+++ b/test/global-decompress.test.js
@@ -322,7 +322,7 @@ describe('It should return the error returned by :', async () => {
       method: 'POST',
       headers: {
         'content-type': 'application/json',
-        'content-encoding': 'whatever'
+        'content-encoding': 'WhatEver'
       },
       payload: createPayload(zlib.createDeflate)
     })
@@ -331,7 +331,7 @@ describe('It should return the error returned by :', async () => {
       statusCode: 400,
       code: 'INVALID',
       error: 'Bad Request',
-      message: 'We don\'t want to deal with whatever.'
+      message: 'We don\'t want to deal with WhatEver.'
     })
   })
 

--- a/test/global-decompress.test.js
+++ b/test/global-decompress.test.js
@@ -117,6 +117,29 @@ describe('It should decompress the request payload :', async () => {
     t.assert.equal(response.body, '@fastify/compress')
   })
 
+  test('using gzip algorithm when `Content-Encoding` request header value uses mixed case', async (t) => {
+    t.plan(2)
+
+    const fastify = Fastify()
+    await fastify.register(compressPlugin)
+
+    fastify.post('/', (request, reply) => {
+      reply.send(request.body.name)
+    })
+
+    const response = await fastify.inject({
+      url: '/',
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'content-encoding': 'GzIp'
+      },
+      payload: createPayload(zlib.createGzip)
+    })
+    t.assert.equal(response.statusCode, 200)
+    t.assert.equal(response.body, '@fastify/compress')
+  })
+
   test('using the `forceRequestEncoding` provided algorithm over the `Content-Encoding` request header value', async (t) => {
     t.plan(2)
 


### PR DESCRIPTION
## Problem

HTTP content-coding names are case-insensitive, but request decompression currently compares the `Content-Encoding` value exactly. A client sending a valid mixed-case value such as `Content-Encoding: GzIp` receives a 415 response instead of having its gzip payload decompressed.

## Fix

Normalize the request `Content-Encoding` value to lowercase before checking the configured supported encodings. The change is limited to the request decompression hook and adds regression coverage for mixed-case gzip.

## Tests

- `npm run test:unit -- test/global-decompress.test.js` — passed (18 tests)
- `npm run lint` — passed
- `npm test` — passed (235 unit tests and 10 TypeScript assertions)
- `npm run benchmark --if-present` — passed; benchmark control stayed within the 10% tolerance
- `git diff --check` — passed

## Compatibility

Lower-case request headers and forced request encodings keep their existing behavior. Only string `Content-Encoding` header matching is normalized; no public API or dependency changes are made.

## Related issue

No current issue or pull request was found for mixed-case request `Content-Encoding` handling. This is an independent reproduction of the protocol case-sensitivity defect; it is distinct from open PR #425, which addresses response `Accept-Encoding` negotiation for issue #305.

#### Checklist

- [x] run `npm run test && npm run benchmark --if-present`
- [x] tests and/or benchmarks are included
- [ ] documentation is changed or added
- [x] commit message and code follows the [Developer's Certification of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [Code of conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)
