### PR TITLE
fix: inherit global options when route options are defined partially (#340)

### DIFF
--- a/index.js
+++ b/index.js
@@ -30,7 +30,7 @@ const defaultSyncThreshold = computeSyncThreshold()
 const InvalidRequestEncodingError = createError('FST_CP_ERR_INVALID_CONTENT_ENCODING', 'Unsupported Content-Encoding: %s', 415)
 const InvalidRequestCompressedPayloadError = createError('FST_CP_ERR_INVALID_CONTENT', 'Could not decompress the request payload using the provided encoding', 400)
 
-function fastifyCompress (fastify, opts, next) {
+function fastifyCompress(fastify, opts, next) {
   const globalCompressParams = processCompressParams(opts)
   const globalDecompressParams = processDecompressParams(opts)
 
@@ -120,7 +120,7 @@ const recommendedDefaultBrotliOptions = {
   }
 }
 
-function processCompressParams (opts) {
+function processCompressParams(opts) {
   /* c8 ignore next 3 */
   if (!opts) {
     return
@@ -200,14 +200,16 @@ function processCompressParams (opts) {
       .sort((a, b) => opts.encodings.indexOf(a) - opts.encodings.indexOf(b))
     : supportedEncodings
 
-  return params
+  return Object.fromEntries(
+    Object.entries(params).filter(([_, value]) => value != undefined)
+  )
 }
 
 // Resolve the synchronous counterpart of a stream compressor.
 // A synchronous method is only picked when it comes from the same `zlib` implementation the
 // stream path would have used, so a custom `zlib` exposing just the stream constructor is
 // never bypassed: its encoding simply keeps using the stream pipeline.
-function resolveSyncCompressor (customZlib, streamMethod, syncMethod, options) {
+function resolveSyncCompressor(customZlib, streamMethod, syncMethod, options) {
   let compressSync
 
   if (customZlib != null && typeof customZlib[syncMethod] === 'function') {
@@ -227,7 +229,7 @@ function resolveSyncCompressor (customZlib, streamMethod, syncMethod, options) {
 // pipeline are allocated per response, and the source payload is released immediately
 // instead of being pinned for as long as the response is in flight.
 // Returns `null` when the payload is not eligible and must be streamed instead.
-function compressPayloadSync (params, reply, encoding, payload, payloadSize) {
+function compressPayloadSync(params, reply, encoding, payload, payloadSize) {
   if (params.syncThreshold <= 0 || payloadSize > params.syncThreshold) return null
 
   const compressSync = params.compressSync[encoding]
@@ -251,7 +253,7 @@ function compressPayloadSync (params, reply, encoding, payload, payloadSize) {
   return compressSync(buffer)
 }
 
-function processDecompressParams (opts) {
+function processDecompressParams(opts) {
   /* c8 ignore next 3 */
   if (!opts) {
     return
@@ -296,10 +298,12 @@ function processDecompressParams (opts) {
     }
   }
 
-  return params
+  return Object.fromEntries(
+    Object.entries(params).filter(([_, value]) => value != undefined)
+  )
 }
 
-function buildRouteCompress (_fastify, params, routeOptions, decorateOnly) {
+function buildRouteCompress(_fastify, params, routeOptions, decorateOnly) {
   // In order to provide a compress method with the same parameter set as the route itself,
   // we decorate the reply at the start of the request
   if (Array.isArray(routeOptions.onRequest)) {
@@ -311,7 +315,7 @@ function buildRouteCompress (_fastify, params, routeOptions, decorateOnly) {
   }
 
   const compressFn = compress(params)
-  function onRequest (_req, reply, next) {
+  function onRequest(_req, reply, next) {
     reply.compress = compressFn
     next()
   }
@@ -328,7 +332,7 @@ function buildRouteCompress (_fastify, params, routeOptions, decorateOnly) {
     routeOptions.onSend = [onSend]
   }
 
-  function onSend (req, reply, payload, next) {
+  function onSend(req, reply, payload, next) {
     if (isFetchResponse(payload)) {
       payload = unwrapFetchResponse(reply, payload)
     }
@@ -416,7 +420,7 @@ function buildRouteCompress (_fastify, params, routeOptions, decorateOnly) {
   }
 }
 
-function buildRouteDecompress (_fastify, params, routeOptions) {
+function buildRouteDecompress(_fastify, params, routeOptions) {
   // Add our decompress handler in the preParsing hook
   if (Array.isArray(routeOptions.preParsing)) {
     routeOptions.preParsing.unshift(preParsing)
@@ -426,7 +430,7 @@ function buildRouteDecompress (_fastify, params, routeOptions) {
     routeOptions.preParsing = [preParsing]
   }
 
-  function preParsing (request, _reply, raw, next) {
+  function preParsing(request, _reply, raw, next) {
     // Get the encoding from the options or from the headers
     let encoding = params.forceEncoding
 
@@ -480,7 +484,7 @@ function buildRouteDecompress (_fastify, params, routeOptions) {
   }
 }
 
-function compress (params) {
+function compress(params) {
   return function (payload) {
     if (payload == null) {
       this.send(new Error('Internal server error'))
@@ -571,7 +575,7 @@ function compress (params) {
   }
 }
 
-function setVaryHeader (reply) {
+function setVaryHeader(reply) {
   if (reply.hasHeader('Vary')) {
     const rawHeaderValue = reply.getHeader('Vary')
     const headerValueArray = Array.isArray(rawHeaderValue) ? rawHeaderValue : [rawHeaderValue]
@@ -583,7 +587,7 @@ function setVaryHeader (reply) {
   }
 }
 
-function onEnd (err) {
+function onEnd(err) {
   // Client disconnection during streaming is expected and handled by Fastify.
   // Do not log "premature close" errors at error level since they are not
   // actual errors - they occur when clients disconnect mid-response.
@@ -597,16 +601,16 @@ function onEnd (err) {
   }
 }
 
-function trackEncodedLength (chunk) {
+function trackEncodedLength(chunk) {
   this.receivedEncodedLength += chunk.length
 }
 
-function removeEncodedLengthTracking () {
+function removeEncodedLengthTracking() {
   this.removeListener('data', trackEncodedLength)
   this.removeListener('end', removeEncodedLengthTracking)
 }
 
-function onDecompressError (request, params, encoding, error) {
+function onDecompressError(request, params, encoding, error) {
   this.log.debug(`compress: invalid request payload - ${error}`)
 
   let errorPayload
@@ -629,7 +633,7 @@ function onDecompressError (request, params, encoding, error) {
 
 const gzipAlias = /\*|x-gzip/gu
 
-function getEncodingHeader (encodings, request) {
+function getEncodingHeader(encodings, request) {
   let header = request.headers['accept-encoding']
   if (header != null) {
     header = header.toLowerCase()
@@ -643,20 +647,20 @@ function getEncodingHeader (encodings, request) {
   }
 }
 
-function shouldCompress (type, compressibleTypes) {
+function shouldCompress(type, compressibleTypes) {
   if (compressibleTypes(type)) return true
   const data = mimedb[type.split(';', 1)[0].trim().toLowerCase()]
   if (data === undefined) return false
   return data.compressible === true
 }
 
-function isCompressed (data) {
+function isCompressed(data) {
   if (isGzip(data)) return 1
   if (isDeflate(data)) return 2
   return 0
 }
 
-function maybeUnzip (payload, serialize) {
+function maybeUnzip(payload, serialize) {
   if (isStream(payload)) return payload
 
   let buf = payload; let result = payload
@@ -678,7 +682,7 @@ function maybeUnzip (payload, serialize) {
   return Readable.from(intoAsyncIterator(result))
 }
 
-function zipStream (deflate, encoding) {
+function zipStream(deflate, encoding) {
   return createPeekTransform(function (data) {
     switch (isCompressed(data)) {
       case 1: return new Minipass()
@@ -688,7 +692,7 @@ function zipStream (deflate, encoding) {
   })
 }
 
-function unzipStream (inflate, maxRecursion) {
+function unzipStream(inflate, maxRecursion) {
   if (!(maxRecursion >= 0)) maxRecursion = 3
   return createPeekTransform(function (data) {
     // This path is never taken, when `maxRecursion` < 0 it is automatically set back to 3
@@ -702,10 +706,10 @@ function unzipStream (inflate, maxRecursion) {
   })
 }
 
-function createError (code, message, statusCode) {
+function createError(code, message, statusCode) {
   code = code.toUpperCase()
 
-  function FastifyCompressError (a) {
+  function FastifyCompressError(a) {
     Error.captureStackTrace(this, FastifyCompressError)
     this.name = 'FastifyCompressError'
     this.code = code

--- a/test/regression/issue-340.test.js
+++ b/test/regression/issue-340.test.js
@@ -1,0 +1,149 @@
+'use strict'
+
+const { test } = require('node:test')
+const zlib = require('node:zlib')
+const Fastify = require('fastify')
+const fastifyCompress = require('../..')
+
+test('global onUnsupportedRequestEncoding should be used when route only overrides onInvalidRequestPayload', async (t) => {
+  let globalCalled = false
+
+  const fastify = Fastify()
+  await fastify.register(fastifyCompress, {
+    global: true,
+    onUnsupportedRequestEncoding: () => {
+      globalCalled = true
+      return { statusCode: 415, code: 'CUSTOM_GLOBAL', message: 'global unsupported' }
+    },
+    onInvalidRequestPayload: () => {
+      return { statusCode: 400, code: 'CUSTOM_GLOBAL', message: 'global invalid' }
+    }
+  })
+
+  fastify.post('/', {
+    decompress: {
+      onInvalidRequestPayload: () => {
+        return { statusCode: 400, code: 'CUSTOM_ROUTE', message: 'route invalid' }
+      }
+    }
+  }, (request, reply) => {
+    reply.send(request.body)
+  })
+
+  const response = await fastify.inject({
+    url: '/',
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'content-encoding': 'whatever'
+    },
+    payload: createPayload(zlib.createDeflate)
+  })
+
+  t.assert.equal(response.statusCode, 415)
+  t.assert.ok(globalCalled, 'global onUnsupportedRequestEncoding should be called when route does not override it')
+})
+
+test('global onInvalidRequestPayload should be used when route only overrides onUnsupportedRequestEncoding', async (t) => {
+  let globalCalled = false
+
+  const fastify = Fastify()
+  await fastify.register(fastifyCompress, {
+    global: true,
+    onInvalidRequestPayload: () => {
+      globalCalled = true
+      return { statusCode: 400, code: 'CUSTOM_GLOBAL', message: 'global invalid' }
+    }
+  })
+
+  fastify.post('/', {
+    decompress: {
+      onUnsupportedRequestEncoding: () => {
+        return { statusCode: 415, code: 'CUSTOM_ROUTE', message: 'route unsupported' }
+      }
+    }
+  }, (request, reply) => {
+    reply.send(request.body)
+  })
+
+  const response = await fastify.inject({
+    url: '/',
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'content-encoding': 'deflate'
+    },
+    payload: createPayload(zlib.createGzip)
+  })
+
+  t.assert.equal(response.statusCode, 400)
+  t.assert.ok(globalCalled, 'global onInvalidRequestPayload should be called when route does not override it')
+})
+
+test('route onUnsupportedRequestEncoding should override global one', async (t) => {
+  let globalCalled = false
+  let routeCalled = false
+
+  const fastify = Fastify()
+  await fastify.register(fastifyCompress, {
+    global: true,
+    onUnsupportedRequestEncoding: () => {
+      globalCalled = true
+      return { statusCode: 415, code: 'CUSTOM_GLOBAL', message: 'global unsupported' }
+    }
+  })
+
+  fastify.post('/', {
+    decompress: {
+      onUnsupportedRequestEncoding: () => {
+        routeCalled = true
+        return { statusCode: 415, code: 'CUSTOM_ROUTE', message: 'route unsupported' }
+      }
+    }
+  }, (request, reply) => {
+    reply.send(request.body)
+  })
+
+  const response = await fastify.inject({
+    url: '/',
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      'content-encoding': 'whatever'
+    },
+    payload: createPayload(zlib.createDeflate)
+  })
+
+  t.assert.equal(response.statusCode, 415)
+  t.assert.ok(routeCalled, 'route onUnsupportedRequestEncoding should be called')
+  t.assert.equal(globalCalled, false, 'global onUnsupportedRequestEncoding should NOT be called')
+})
+
+test('global onInvalidRequestPayload should be inherited when route only sets removeContentLengthHeader (compress)', async (t) => {
+  let globalCalled = false
+
+  const fastify = Fastify()
+  await fastify.register(fastifyCompress, {
+    global: true,
+    onUnsupportedEncoding: () => {
+      globalCalled = true
+      return { statusCode: 400, code: 'CUSTOM_GLOBAL', message: 'global unsupported encoding' }
+    }
+  })
+
+  fastify.get('/', {
+    compress: {
+      removeContentLengthHeader: false
+    }
+  }, async () => ({ ok: true }))
+
+  const response = await fastify.inject({
+    method: 'GET',
+    url: '/',
+    headers: {
+      'accept-encoding': 'unsupported-encoding-value'
+    }
+  })
+
+  t.assert.ok(globalCalled, 'global onUnsupportedEncoding should be called when route only overrides removeContentLengthHeader')
+})

--- a/test/regression/issue-340.test.js
+++ b/test/regression/issue-340.test.js
@@ -5,6 +5,10 @@ const zlib = require('node:zlib')
 const Fastify = require('fastify')
 const fastifyCompress = require('../..')
 
+function createPayload(compressor) {
+  return Buffer.from(JSON.stringify({ name: 'fastify' }))
+}
+
 test('global onUnsupportedRequestEncoding should be used when route only overrides onInvalidRequestPayload', async (t) => {
   let globalCalled = false
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests and possibly benchmarks.

Contributors guide: https://github.com/fastify/fastify/blob/main/CONTRIBUTING.md

By making a contribution to this project, I certify that:

* (a) The contribution was created in whole or in part by me and I
  have the right to submit it under the open source license
  indicated in the file; or

* (b) The contribution is based upon previous work that, to the best
  of my knowledge, is covered under an appropriate open source
  license and I have the right under that license to submit that
  work with modifications, whether created in whole or in part
  by me, under the same open source license (unless I am
  permitted to submit under a different license), as indicated
  in the file; or

* (c) The contribution was provided directly to me by some other
  person who certified (a), (b) or (c) and I have not modified
  it.

* (d) I understand and agree that this project and the contribution
  are public and that a record of the contribution (including all
  personal information I submit with it, including my sign-off) is
  maintained indefinitely and may be redistributed consistent with
  this project or the open source license(s) involved.
-->
# Fix: Inherit Global Options When Route Options Are Defined Partially (#340)

## Problem

Global options (e.g. `onInvalidRequestPayload`, `onUnsupportedRequestEncoding`) registered at the plugin level are ignored when a route defines partial `compress`/`decompress` options.

## Root Cause

`processCompressParams` and `processDecompressParams` always return all fields, including `undefined` for unset values.

During:

```js
Object.assign({}, globalParams, routeParams)
```

the `undefined` values overwrite the global options.

## Fix

Filter out `undefined` values before returning from `processCompressParams` and `processDecompressParams`.

Before:

```js
return params
```

After:

```js
return Object.fromEntries(
  Object.entries(params).filter(([_, value]) => value != undefined)
)
```

This ensures `Object.assign` only applies defined route values, allowing global options to serve as fallbacks.

**Merge priority:** route option > global option > default option

## Checklist

* [ ] Run `npm run test && npm run benchmark --if-present`
* [ ] Tests and/or benchmarks are included
* [ ] Documentation is changed or added
* [ ] Commit message and code follow the [[Developer's Certificate of Origin](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11)](https://github.com/fastify/.github/blob/main/CONTRIBUTING.md#developers-certificate-of-origin-11) and the [[Code of Conduct](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)](https://github.com/fastify/.github/blob/main/CODE_OF_CONDUCT.md)